### PR TITLE
Support reading and writing Buffers in-place.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ ip.mask('192.168.1.134', '255.255.255.0') // 192.168.1.0
 ip.not('255.255.255.0') // 0.0.0.255
 ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
+
+// operate on buffers in-place
+var buf = new Buffer(128);
+var offset = 64;
+ip.toBuffer('127.0.0.1', buf, offset);  // [127, 0, 0, 1] at offset 64
+ip.toString(buf, offset, 4);            // '127.0.0.1'
 ```
 
 ### License

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -2,13 +2,16 @@ var ip = exports,
     Buffer = require('buffer').Buffer,
     os = require('os');
 
-ip.toBuffer = function toBuffer(ip) {
+ip.toBuffer = function toBuffer(ip, buff, offset) {
+  offset = ~~offset;
+
   var result;
 
   if (/^(\d{1,3}\.){3,3}\d{1,3}$/.test(ip)) {
-    result = new Buffer(ip.split(/\./g).map(function(byte) {
-      return parseInt(byte, 10) & 0xff;
-    }));
+    result = buff || new Buffer(offset + 4);
+    ip.split(/\./g).map(function(byte) {
+      result[offset++] = parseInt(byte, 10) & 0xff;
+    });
   } else if (/^[a-f0-9:]+$/.test(ip)) {
     var s = ip.split(/::/g, 2),
         head = (s[0] || '').split(/:/g, 8),
@@ -25,12 +28,12 @@ ip.toBuffer = function toBuffer(ip) {
       while (head.length + tail.length < 8) head.push('0000');
     }
 
-    result = new Buffer(head.concat(tail).map(function(word) {
+    result = buff || new Buffer(offset + 16);
+    head.concat(tail).map(function(word) {
       word = parseInt(word, 16);
-      return [(word >> 8) & 0xff, word & 0xff];
-    }).reduce(function(prev, next) {
-      return prev.concat(next);
-    }));
+      result[offset++] = (word >> 8) & 0xff;
+      result[offset++] = word & 0xff;
+    });
   } else {
     throw Error('Invalid ip address: ' + ip);
   }
@@ -38,18 +41,21 @@ ip.toBuffer = function toBuffer(ip) {
   return result;
 };
 
-ip.toString = function toString(buff) {
+ip.toString = function toString(buff, offset, length) {
+  offset = ~~offset;
+  length = length || (buff.length - offset);
+
   var result = [];
-  if (buff.length === 4) {
+  if (length === 4) {
     // IPv4
-    for (var i = 0; i < buff.length; i++) {
-      result.push(buff[i]);
+    for (var i = 0; i < length; i++) {
+      result.push(buff[offset + i]);
     }
     result = result.join('.');
-  } else if (buff.length === 16) {
+  } else if (length === 16) {
     // IPv6
-    for (var i = 0; i < buff.length; i += 2) {
-      result.push(buff.readUInt16BE(i).toString(16));
+    for (var i = 0; i < length; i += 2) {
+      result.push(buff.readUInt16BE(offset + i).toString(16));
     }
     result = result.join(':');
     result = result.replace(/(^|:)0(:0)*:0(:|$)/, '$1::$3');

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -11,12 +11,32 @@ describe('IP library for node.js', function() {
       assert.equal(ip.toString(buf), '127.0.0.1');
     });
 
+    it('should convert to buffer IPv4 address in-place', function() {
+      var buf = new Buffer(128);
+      var offset = 64;
+      ip.toBuffer('127.0.0.1', buf, offset);
+      assert.equal(buf.toString('hex', offset, offset + 4), '7f000001');
+      assert.equal(ip.toString(buf, offset, 4), '127.0.0.1');
+    });
+
     it('should convert to buffer IPv6 address', function() {
       var buf = ip.toBuffer('::1');
       assert(/(00){15,15}01/.test(buf.toString('hex')));
       assert.equal(ip.toString(buf), '::1');
       assert.equal(ip.toString(ip.toBuffer('1::')), '1::');
       assert.equal(ip.toString(ip.toBuffer('abcd::dcba')), 'abcd::dcba');
+    });
+
+    it('should convert to buffer IPv6 address in-place', function() {
+      var buf = new Buffer(128);
+      var offset = 64;
+      ip.toBuffer('::1', buf, offset);
+      assert(/(00){15,15}01/.test(buf.toString('hex', offset, offset + 16)));
+      assert.equal(ip.toString(buf, offset, 16), '::1');
+      assert.equal(ip.toString(ip.toBuffer('1::', buf, offset),
+                               offset, 16), '1::');
+      assert.equal(ip.toString(ip.toBuffer('abcd::dcba', buf, offset),
+                               offset, 16), 'abcd::dcba');
     });
   });
 


### PR DESCRIPTION
Optionally allow the caller to provide an existing Buffer and offset
to toString() and toBuffer().  If these arguments are left off, then
act as the API did previously either creating the Buffer in toBuffer()
or assuming an offset of zero in toString().

The goal of these changes is to reduce object creation by avoiding
unnecessary slice() calls.

Tests included.
