### PR TITLE
Add support for /32 and /31 length subnet masks

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -160,12 +160,17 @@ ip.subnet = function subnet(addr, mask) {
 
   return {
     networkAddress: ip.fromLong(networkAddress),
-    firstAddress: ip.fromLong(networkAddress + 1),
-    lastAddress: ip.fromLong(networkAddress + numberOfAddresses - 2),
-    broadcastAddress: ip.fromLong(networkAddress + numberOfAddresses - 1),
+    firstAddress: numberOfAddresses <= 2 ? 
+                    ip.fromLong(networkAddress) : 
+                    ip.fromLong(networkAddress + 1),
+    lastAddress: numberOfAddresses <= 2 ? 
+                    ip.fromLong(networkAddress + numberOfAddresses - 1) : 
+                    ip.fromLong(networkAddress + numberOfAddresses - 2),
+    broadcastAddress: ip.fromLong(networkAddress + numberOfAddresses - 1), 
     subnetMask: mask,
     subnetMaskLength: maskLength,
-    numHosts: numberOfAddresses - 2,
+    numHosts: numberOfAddresses <= 2 ? 
+                numberOfAddresses : numberOfAddresses - 2,
     length: numberOfAddresses
   };
 }
@@ -256,7 +261,7 @@ ip.isEqual = function isEqual(a, b) {
 ip.isPrivate = function isPrivate(addr) {
   return addr.match(/^10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/) != null ||
     addr.match(/^192\.168\.([0-9]{1,3})\.([0-9]{1,3})/) != null ||
-    addr.match(/^172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})/) != null ||
+    addr.match(/^172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})/)!=null ||
     addr.match(/^127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/) != null ||
     addr.match(/^169\.254\.([0-9]{1,3})\.([0-9]{1,3})/) != null ||
     addr.match(/^fc00:/) != null || addr.match(/^fe80:/) != null ||

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -116,6 +116,38 @@ describe('IP library for node.js', function() {
     });
   });
 
+  describe('subnet() method with mask length 32', function() {
+    // Test cases calculated with http://www.subnet-calculator.com/
+    var ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.255');
+    it('should compute ipv4 network\'s first address', function() {
+      assert.equal(ipv4Subnet.firstAddress, '192.168.1.134');
+    });
+
+    it('should compute ipv4 network\'s last address', function() {
+      assert.equal(ipv4Subnet.lastAddress, '192.168.1.134');
+    });
+
+    it('should compute ipv4 subnet number of addressable hosts', function() {
+      assert.equal(ipv4Subnet.numHosts, 1);
+    });
+  });
+
+  describe('subnet() method with mask length 31', function() {
+    // Test cases calculated with http://www.subnet-calculator.com/
+    var ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.254');
+    it('should compute ipv4 network\'s first address', function() {
+      assert.equal(ipv4Subnet.firstAddress, '192.168.1.134');
+    });
+
+    it('should compute ipv4 network\'s last address', function() {
+      assert.equal(ipv4Subnet.lastAddress, '192.168.1.135');
+    });
+
+    it('should compute ipv4 subnet number of addressable hosts', function() {
+      assert.equal(ipv4Subnet.numHosts, 2);
+    });
+  });
+
   describe('cidrSubnet() method', function() {
     // Test cases calculated with http://www.subnet-calculator.com/
     var ipv4Subnet = ip.cidrSubnet('192.168.1.134/26');
@@ -140,7 +172,7 @@ describe('IP library for node.js', function() {
       assert.equal(ipv4Subnet.length, 64);
     });
 
-    it('should compute an ipv4 subnet number of addressable hosts', function() {
+    it('should compute an ipv4 subnet number of addressable hosts', function(){
       assert.equal(ipv4Subnet.numHosts, 62);
     });
 
@@ -202,7 +234,7 @@ describe('IP library for node.js', function() {
       assert.equal(ip.isPrivate('12.1.2.3'), false);
     });
 
-    it('should check if an address is from a private IPv6 network', function() {
+    it('should check if an address is from a private IPv6 network', function(){
       assert.equal(ip.isPrivate('fe80::f2de:f1ff:fe3f:307e'), true);
     });
 


### PR DESCRIPTION
- Add checks that the numberOfAddresses is greater than 2, otherwise
  treat the broadcast and network addresses as first and last addresses.
- numHosts returns correct size due to the first and last address
  change for /31 and /32 networks.
- Add tests.
