### PR TITLE
Add a contains() function to subnets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ ip.subnet('192.168.1.134', '255.255.255.192')
 //   subnetMask: '255.255.255.192',
 //   subnetMaskLength: 26,
 //   numHosts: 62,
-//   length: 64 }
+//   length: 64,
+//   contains: function(addr){...} }
 ip.cidrSubnet('192.168.1.134/26')
 // Same as previous.
+
+// range checking
+ip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true
+
 
 // ipv4 long conversion
 ip.toLong('127.0.0.1'); // 2130706433

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -173,7 +173,7 @@ ip.subnet = function subnet(addr, mask) {
                 numberOfAddresses : numberOfAddresses - 2,
     length: numberOfAddresses,
     contains: function(other){
-        return networkAddress === ip.toLong(ip.mask(other, mask));
+      return networkAddress === ip.toLong(ip.mask(other, mask));
     }
   };
 }

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -171,7 +171,10 @@ ip.subnet = function subnet(addr, mask) {
     subnetMaskLength: maskLength,
     numHosts: numberOfAddresses <= 2 ?
                 numberOfAddresses : numberOfAddresses - 2,
-    length: numberOfAddresses
+    length: numberOfAddresses,
+    contains: function(other){
+        return networkAddress === ip.toLong(ip.mask(other, mask));
+    }
   };
 }
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -192,11 +192,11 @@ describe('IP library for node.js', function() {
       assert.equal(ipv4Subnet.subnetMaskLength, 26);
     });
     
-    it('should know whether a subnet contains an address', function(){
+    it('should know whether a subnet contains an address', function() {
       assert.equal(ipv4Subnet.contains('192.168.1.180'), true);
     });
 
-    it('should know whether a subnet does not contain an address', function(){
+    it('should know whether a subnet contains an address', function() {
       assert.equal(ipv4Subnet.contains('192.168.1.195'), false);
     });
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -114,6 +114,14 @@ describe('IP library for node.js', function() {
     it('should compute ipv4 subnet mask\'s length', function() {
       assert.equal(ipv4Subnet.subnetMaskLength, 26);
     });
+    
+    it('should know whether a subnet contains an address', function(){
+      assert.equal(ipv4Subnet.contains('192.168.1.180'), true);
+    });
+
+    it('should know whether a subnet does not contain an address', function(){
+      assert.equal(ipv4Subnet.contains('192.168.1.195'), false);
+    });
   });
 
   describe('subnet() method with mask length 32', function() {
@@ -183,6 +191,15 @@ describe('IP library for node.js', function() {
     it('should compute an ipv4 subnet mask\'s length', function() {
       assert.equal(ipv4Subnet.subnetMaskLength, 26);
     });
+    
+    it('should know whether a subnet contains an address', function(){
+      assert.equal(ipv4Subnet.contains('192.168.1.180'), true);
+    });
+
+    it('should know whether a subnet does not contain an address', function(){
+      assert.equal(ipv4Subnet.contains('192.168.1.195'), false);
+    });
+
   });
 
   describe('cidr() method', function() {


### PR DESCRIPTION
This implements the feature request in #18.  However, I opted for hanging a function off of the subnet() return value, rather than a top-level function called subnetContains.  It could obviously be switched around, but I personally favor this approach.  I don't know if others are expecting subnet() to never return an object with a function as a member, which would be the only downside I can see to this method.

This includes tests and an example of usage in the README.md.