### PR TITLE
netClass method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ip.cidr('192.168.1.134/26') // 192.168.1.128
 ip.not('255.255.255.0') // 0.0.0.255
 ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
+ip.netClass('192.168.1.134') // C
 
 // operate on buffers in-place
 var buf = new Buffer(128);
@@ -33,7 +34,9 @@ ip.subnet('192.168.1.134', '255.255.255.192')
 //   subnetMask: '255.255.255.192',
 //   subnetMaskLength: 26,
 //   numHosts: 62,
-//   length: 64 }
+//   length: 64,
+//	 netClass : 'C' }
+
 ip.cidrSubnet('192.168.1.134/26')
 // Same as previous.
 

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -171,7 +171,8 @@ ip.subnet = function subnet(addr, mask) {
     subnetMaskLength: maskLength,
     numHosts: numberOfAddresses <= 2 ?
                 numberOfAddresses : numberOfAddresses - 2,
-    length: numberOfAddresses
+    length: numberOfAddresses,
+		netClass : ip.netClass(addr)
   };
 }
 
@@ -373,6 +374,36 @@ ip.fromLong = function fromInt(ipl){
       (ipl>>16 & 255) +'.' +
       (ipl>>8 & 255) +'.' +
       (ipl & 255) );
+};
+
+// function netClass(addr) 
+// @addr {string} ipv4 string
+// Computes the network address based on the ipv4 address
+// Network classes were gotten from https://tools.ietf.org/html/rfc1878
+// more information on this thread https://learningnetwork.cisco.com/thread/34420
+
+ip.netClass = function netClass(addr) {
+	var bufferIp, 
+			firstBlock,
+			cIp;
+	if (typeof addr !== 'string') {
+		throw new Error('addr must be string');
+	}
+	bufferIp = ip.toBuffer(addr);
+	firstBlock  = bufferIp[0];
+	if (bufferIp.length !== 4) {
+		throw new Error('family must be ipv4'); 
+	}
+	if (firstBlock >= 0 && firstBlock < 128) {
+		cIp = 'A';
+	}
+	else if (firstBlock >= 128 && firstBlock < 192) {
+		cIp = 'B';
+	}
+	else if (firstBlock >= 192) {
+		cIp = 'C';
+	}
+	return cIp;
 };
 
 function _normalizeFamily(family) {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -114,6 +114,10 @@ describe('IP library for node.js', function() {
     it('should compute ipv4 subnet mask\'s length', function() {
       assert.equal(ipv4Subnet.subnetMaskLength, 26);
     });
+		
+		it('should compute ipv4 class', function() {
+			assert.equal(ipv4Subnet.netClass, 'C'); 
+		});
   });
 
   describe('subnet() method with mask length 32', function() {
@@ -183,6 +187,10 @@ describe('IP library for node.js', function() {
     it('should compute an ipv4 subnet mask\'s length', function() {
       assert.equal(ipv4Subnet.subnetMaskLength, 26);
     });
+
+		it('should compute ipv4 class', function() {
+			assert.equal(ipv4Subnet.netClass, 'C'); 
+		});
   });
 
   describe('cidr() method', function() {
@@ -351,5 +359,27 @@ describe('IP library for node.js', function() {
       assert.equal(ip.fromLong(2130706433), '127.0.0.1');
       assert.equal(ip.fromLong(4294967295), '255.255.255.255');
     });
-  })
+  });
+
+	describe('netClass() method', function() {
+		it('should respond with class A', function() {
+			assert.equal(ip.netClass('10.168.0.0'), 'A');
+		});
+		it('should respond with class B', function() {
+			assert.equal(ip.netClass('172.16.0.0'), 'B');
+		});
+		it('should respond with class C', function() {
+			assert.equal(ip.netClass('192.168.0.0'), 'C');
+		});
+		it('should throw error \"addr must be string\"', function() {
+			assert.throws(function() {
+				ip.netClass(123132132);
+			}, /string/);
+		});
+		it('should throw error \"family must be ipv4\"', function() {
+			assert.throws(function() {
+				ip.netClass('abcd::dcba');
+			}, /ipv4/);
+		});
+	});
 });


### PR DESCRIPTION
I've added a new method to compute the network class of a given ipv4 address.
Example:

ip.netClass('192.168.0.0') would return "C".
ip.subnet/ip.cidrSubnet would display the network class in another JSON's property.

Network class was gotten from the following <a href="https://tools.ietf.org/html/rfc1878">RFC</a>.
more info about classful network can be found on this <a href="https://learningnetwork.cisco.com/thread/34420">thread</a>.

If you got any questions please let me know.

Regards.
Luis Valdovinos
