### PR TITLE
set isLoopback of ipv4 to 127.0.0.1/8

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -285,7 +285,7 @@ ip.isPublic = function isPublic(addr) {
 };
 
 ip.isLoopback = function isLoopback(addr) {
-  return /^127\.0\.0\.1$/.test(addr) ||
+  return /^127\.\d+\.\d+\.\d+$/.test(addr) ||
     /^fe80::1$/.test(addr) ||
     /^::1$/.test(addr) ||
     /^::$/.test(addr);

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -286,8 +286,14 @@ describe('IP library for node.js', function() {
       });
     });
 
-    describe('8.8.8.8', function() {
-      it('should respond with false', function() {
+    describe('127.8.8.8', function () {
+      it('should respond with true', function () {
+        assert.ok(ip.isLoopback('127.8.8.8'))
+      });
+    });
+
+    describe('8.8.8.8', function () {
+      it('should respond with false', function () {
         assert.equal(ip.isLoopback('8.8.8.8'), false);
       });
     });


### PR DESCRIPTION
Loopback address of IPv4 should be 127.0.0.1/8, instead of 127.0.0.1/32. That is to say, 127.8.8.8 is also a valid loopback address.

```ip.isLoopback``` is optimized in this commit to fix this problem.

Ref : [http://en.wikipedia.org/wiki/Localhost#Name_resolution](http://en.wikipedia.org/wiki/Localhost#Name_resolution)