### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   },
   "scripts": {
     "test": "mocha --reporter spec test/*-test.js"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
npm recently updated its guidelines on license metadata in package.json files. The new guidelines ask maintainers to use the SPDX standard’s license expression syntax to show how their work is licensed in a machine-readable way. You will get a warning if you don’t.

https://github.com/npm/npm/releases/tag/v2.10.0