### PR TITLE
Bug fix for IPv6 section in toBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ ip.cidr('192.168.1.134/26') // 192.168.1.128
 ip.not('255.255.255.0') // 0.0.0.255
 ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
+ip.isV4Format('127.0.0.1'); // true
+ip.isV6Format('::ffff:127.0.0.1'); // true
 
 // operate on buffers in-place
 var buf = new Buffer(128);

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -7,34 +7,54 @@ ip.toBuffer = function toBuffer(ip, buff, offset) {
 
   var result;
 
-  if (/^(\d{1,3}\.){3,3}\d{1,3}$/.test(ip)) {
+  if (this.isV4Format(ip)) {
     result = buff || new Buffer(offset + 4);
     ip.split(/\./g).map(function(byte) {
       result[offset++] = parseInt(byte, 10) & 0xff;
     });
-  } else if (/^[a-f0-9:]+$/.test(ip)) {
-    var s = ip.split(/::/g, 2),
-        head = (s[0] || '').split(/:/g, 8),
-        tail = (s[1] || '').split(/:/g, 8);
-
-    if (tail.length === 0) {
-      // xxxx::
-      while (head.length < 8) head.push('0000');
-    } else if (head.length === 0) {
-      // ::xxxx
-      while (tail.length < 8) tail.unshift('0000');
-    } else {
-      // xxxx::xxxx
-      while (head.length + tail.length < 8) head.push('0000');
+  } else if (this.isV6Format(ip)) {
+    var sections = ip.split(':', 8);
+    
+    for(var i = 0; i < sections.length; i++) {
+      if(this.isV4Format(sections[i])) {
+        var v4Buffer = this.toBuffer(sections[i]);
+        sections[i] = v4Buffer.slice(0, 2).toString('hex');
+            
+        if(++i < 8) {
+          sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'))
+        }
+      }
     }
-
+    
+    if(sections !== 8) {
+      if(sections[0] === '') {
+        while(sections.length < 8) sections.unshift('0');
+      }
+      else if(sections[sections.length] === '') {
+        while(sections.length < 8) sections.push('0');
+      }
+      else {
+        var i = 0;
+        for(; i < sections.length; i++) {
+          if(sections[i] === '') break;
+        }
+        var argv = [ i, 1 ];
+        for(var o = 9 - sections.length; o > 0; o--) {
+          argv.push('0');
+        }
+        sections.splice.apply(sections, argv);
+      }
+    }
+      
     result = buff || new Buffer(offset + 16);
-    head.concat(tail).map(function(word) {
+    sections.map(function(word) {
       word = parseInt(word, 16);
       result[offset++] = (word >> 8) & 0xff;
       result[offset++] = word & 0xff;
     });
-  } else {
+  }
+  
+  if(!result) {
     throw Error('Invalid ip address: ' + ip);
   }
 
@@ -64,6 +84,17 @@ ip.toString = function toString(buff, offset, length) {
 
   return result;
 };
+
+var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/,
+  ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
+
+ip.isV4Format = function(ip) {
+  return ipv4Regex.test(ip);
+}
+
+ip.isV6Format = function(ip) {
+  return ipv6Regex.test(ip);
+}
 
 ip.fromPrefixLen = function fromPrefixLen(prefixlen, family) {
   if (prefixlen > 32) {


### PR DESCRIPTION
The `toBuffer` function would fail when using a valid IPv6 address with inline IPv4 format. Reworked the IPv6 section to support this now.

Example:
`
require('ip').toBuffer('::ffff:127.0.0.1')
`

Also added isV4Format(ip) and isV6Format(ip) functions