### PR TITLE
do string comparisons in isLoopback, use isLoopback in isPrivate, make toBuffer less loopy

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -23,15 +23,9 @@ ip.toBuffer = function toBuffer(ip, buff, offset) {
     var head = (s[0] || '').split(/:/g, 8);
     var tail = (s[1] || '').split(/:/g, 8);
 
-    if (tail.length === 0) {
-      // xxxx::
-      while (head.length < 8) head.push('0000');
-    } else if (head.length === 0) {
-      // ::xxxx
-      while (tail.length < 8) tail.unshift('0000');
-    } else {
-      // xxxx::xxxx
-      while (head.length + tail.length < 8) head.push('0000');
+    // fill in for ::
+    for (var i = 0; i < 8 - (head.length + tail.length); i++) {
+      head.push('0000');
     }
 
     result = buff || new Buffer(offset + 16);

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -269,15 +269,14 @@ ip.isEqual = function isEqual(a, b) {
 };
 
 ip.isPrivate = function isPrivate(addr) {
-  return /^10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^192\.168\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^169\.254\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
+  return ip.isLoopback(addr) ||
+    /^10\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/.test(addr) ||
+    /^192\.168\.(\d{1,3})\.(\d{1,3})/.test(addr) ||
+    /^172\.(1[6-9]|2\d|30|31)\.(\d{1,3})\.(\d{1,3})/.test(addr) ||
+    /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/.test(addr) ||
+    /^169\.254\.(\d{1,3})\.(\d{1,3})/.test(addr) ||
     /^fc00:/.test(addr) ||
-    /^fe80:/.test(addr) ||
-    /^::1$/.test(addr) ||
-    /^::$/.test(addr);
+    /^fe80:/.test(addr);
 };
 
 ip.isPublic = function isPublic(addr) {

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -285,10 +285,10 @@ ip.isPublic = function isPublic(addr) {
 };
 
 ip.isLoopback = function isLoopback(addr) {
-  return /^127\.0\.0\.1$/.test(addr) ||
-    /^fe80::1$/.test(addr) ||
-    /^::1$/.test(addr) ||
-    /^::$/.test(addr);
+  return addr === '127.0.0.1' ||
+    addr === '::1' ||
+    addr === '::' ||
+    addr === 'fe80::1';
 };
 
 ip.loopback = function loopback(family) {


### PR DESCRIPTION
I think I did this wrong - I had another pull request open and I wound up creating a new one by accident.  (closing that one in favor of this one)
