### PR TITLE
IPv6 functionality fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# IP
+# IP  
+[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  
+
 IP address utilities for node.js
 
+## Installation
+
+###  npm
+```shell
+npm install ip
+```
+
+### git
+
+```shell
+git clone https://github.com/indutny/node-ip.git
+```
+  
 ## Usage
 Get your ip address, compare ip addresses, validate ip addresses, etc.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ ip.cidr('192.168.1.134/26') // 192.168.1.128
 ip.not('255.255.255.0') // 0.0.0.255
 ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
+ip.isV4Format('127.0.0.1'); // true
+ip.isV6Format('::ffff:127.0.0.1'); // true
 
 // operate on buffers in-place
 var buf = new Buffer(128);

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -344,7 +344,7 @@ ip.loopback = function loopback(family) {
 //             If not found see `undefined`.
 //   * 'public': the first public ip address of family.
 //   * 'private': the first private ip address of family.
-//   * undefined: First address with `ipv4` or loopback addres `127.0.0.1`.
+//   * undefined: First address with `ipv4` or loopback address `127.0.0.1`.
 //
 ip.address = function address(name, family) {
   var interfaces = os.networkInterfaces();

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -16,47 +16,44 @@ ip.toBuffer = function toBuffer(ip, buff, offset) {
     });
   } else if (this.isV6Format(ip)) {
     var sections = ip.split(':', 8);
-    
-    for(var i = 0; i < sections.length; i++) {
-      if(this.isV4Format(sections[i])) {
-        var v4Buffer = this.toBuffer(sections[i]);
+
+    var i;
+    for (i = 0; i < sections.length; i++) {
+      var isv4 = this.isV4Format(sections[i]);
+      var v4Buffer;
+
+      if (isv4) {
+        v4Buffer = this.toBuffer(sections[i]);
         sections[i] = v4Buffer.slice(0, 2).toString('hex');
-            
-        if(++i < 8) {
-          sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'))
-        }
+      }
+
+      if (v4Buffer && ++i < 8) {
+        sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'));
       }
     }
-    
-    if(sections !== 8) {
-      if(sections[0] === '') {
-        while(sections.length < 8) sections.unshift('0');
+
+    if (sections[0] === '') {
+      while (sections.length < 8) sections.unshift('0');
+    } else if (sections[sections.length - 1] === '') {
+      while (sections.length < 8) sections.push('0');
+    } else if (sections.length < 8) {
+      for (i = 0; i < sections.length && sections[i] !== ''; i++);
+      var argv = [ i, 1 ];
+      for (i = 9 - sections.length; i > 0; i--) {
+        argv.push('0');
       }
-      else if(sections[sections.length] === '') {
-        while(sections.length < 8) sections.push('0');
-      }
-      else {
-        var i = 0;
-        for(; i < sections.length; i++) {
-          if(sections[i] === '') break;
-        }
-        var argv = [ i, 1 ];
-        for(var o = 9 - sections.length; o > 0; o--) {
-          argv.push('0');
-        }
-        sections.splice.apply(sections, argv);
-      }
+      sections.splice.apply(sections, argv);
     }
-      
+
     result = buff || new Buffer(offset + 16);
-    sections.map(function(word) {
-      word = parseInt(word, 16);
+    for (i = 0; i < sections.length; i++) {
+      var word = parseInt(sections[i], 16);
       result[offset++] = (word >> 8) & 0xff;
       result[offset++] = word & 0xff;
-    });
+    }
   }
-  
-  if(!result) {
+
+  if (!result) {
     throw Error('Invalid ip address: ' + ip);
   }
 
@@ -87,15 +84,19 @@ ip.toString = function toString(buff, offset, length) {
   return result;
 };
 
-var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/,
-  ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
+var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
+var ipv6Regex =
+    /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
 
-ip.isV4Format = function(ip) {
+ip.isV4Format = function isV4Format(ip) {
   return ipv4Regex.test(ip);
-}
+};
 
-ip.isV6Format = function(ip) {
+ip.isV6Format = function isV6Format(ip) {
   return ipv6Regex.test(ip);
+};
+function _normalizeFamily(family) {
+  return family ? family.toLowerCase() : 'ipv4';
 }
 
 ip.fromPrefixLen = function fromPrefixLen(prefixlen, family) {
@@ -292,13 +293,15 @@ ip.isEqual = function isEqual(a, b) {
 };
 
 ip.isPrivate = function isPrivate(addr) {
-  return /^10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^192\.168\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^169\.254\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^fc00:/.test(addr) ||
-    /^fe80:/.test(addr) ||
+  return /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/
+      .test(addr) ||
+    /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
+    /^(::f{4}:)?172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})$/
+      .test(addr) ||
+    /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
+    /^(::f{4}:)?169\.254\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
+    /^fc00:/i.test(addr) ||
+    /^fe80:/i.test(addr) ||
     /^::1$/.test(addr) ||
     /^::$/.test(addr);
 };
@@ -308,7 +311,8 @@ ip.isPublic = function isPublic(addr) {
 };
 
 ip.isLoopback = function isLoopback(addr) {
-  return /^127\.\d+\.\d+\.\d+$/.test(addr) ||
+  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
+      .test(addr) ||
     /^fe80::1$/.test(addr) ||
     /^::1$/.test(addr) ||
     /^::$/.test(addr);

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -9,38 +9,54 @@ ip.toBuffer = function toBuffer(ip, buff, offset) {
 
   var result;
 
-  if (/^::ffff:(\d{1,3}\.){3,3}\d{1,3}$/.test(ip)) {
-    ip = ip.replace(/^::ffff:/, '');
-  }
-
-  if (/^(\d{1,3}\.){3,3}\d{1,3}$/.test(ip)) {
+  if (this.isV4Format(ip)) {
     result = buff || new Buffer(offset + 4);
     ip.split(/\./g).map(function(byte) {
       result[offset++] = parseInt(byte, 10) & 0xff;
     });
-  } else if (/^[a-f0-9:]+$/.test(ip)) {
-    var s = ip.split(/::/g, 2);
-    var head = (s[0] || '').split(/:/g, 8);
-    var tail = (s[1] || '').split(/:/g, 8);
-
-    if (tail.length === 0) {
-      // xxxx::
-      while (head.length < 8) head.push('0000');
-    } else if (head.length === 0) {
-      // ::xxxx
-      while (tail.length < 8) tail.unshift('0000');
-    } else {
-      // xxxx::xxxx
-      while (head.length + tail.length < 8) head.push('0000');
+  } else if (this.isV6Format(ip)) {
+    var sections = ip.split(':', 8);
+    
+    for(var i = 0; i < sections.length; i++) {
+      if(this.isV4Format(sections[i])) {
+        var v4Buffer = this.toBuffer(sections[i]);
+        sections[i] = v4Buffer.slice(0, 2).toString('hex');
+            
+        if(++i < 8) {
+          sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'))
+        }
+      }
     }
-
+    
+    if(sections !== 8) {
+      if(sections[0] === '') {
+        while(sections.length < 8) sections.unshift('0');
+      }
+      else if(sections[sections.length] === '') {
+        while(sections.length < 8) sections.push('0');
+      }
+      else {
+        var i = 0;
+        for(; i < sections.length; i++) {
+          if(sections[i] === '') break;
+        }
+        var argv = [ i, 1 ];
+        for(var o = 9 - sections.length; o > 0; o--) {
+          argv.push('0');
+        }
+        sections.splice.apply(sections, argv);
+      }
+    }
+      
     result = buff || new Buffer(offset + 16);
-    head.concat(tail).map(function(word) {
+    sections.map(function(word) {
       word = parseInt(word, 16);
       result[offset++] = (word >> 8) & 0xff;
       result[offset++] = word & 0xff;
     });
-  } else {
+  }
+  
+  if(!result) {
     throw Error('Invalid ip address: ' + ip);
   }
 
@@ -71,8 +87,15 @@ ip.toString = function toString(buff, offset, length) {
   return result;
 };
 
-function _normalizeFamily(family) {
-  return family ? family.toLowerCase() : 'ipv4';
+var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/,
+  ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
+
+ip.isV4Format = function(ip) {
+  return ipv4Regex.test(ip);
+}
+
+ip.isV6Format = function(ip) {
+  return ipv6Regex.test(ip);
 }
 
 ip.fromPrefixLen = function fromPrefixLen(prefixlen, family) {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -43,8 +43,16 @@ describe('IP library for node.js', function() {
 
     it('should convert to buffer IPv6 mapped IPv4 address', function() {
       var buf = ip.toBuffer('::ffff:127.0.0.1');
-      assert.equal(buf.toString('hex'), '7f000001');
-      assert.equal(ip.toString(buf), '127.0.0.1');
+      assert.equal(buf.toString('hex'), '00000000000000000000ffff7f000001');
+      assert.equal(ip.toString(buf), '::ffff:7f00:1');
+
+      buf = ip.toBuffer('ffff::127.0.0.1');
+      assert.equal(buf.toString('hex'), 'ffff000000000000000000007f000001');
+      assert.equal(ip.toString(buf), 'ffff::7f00:1');
+
+      buf = ip.toBuffer('0:0:0:0:0:ffff:127.0.0.1');
+      assert.equal(buf.toString('hex'), '00000000000000000000ffff7f000001');
+      assert.equal(ip.toString(buf), '::ffff:7f00:1');
     });
   });
 


### PR DESCRIPTION
Fixes some unexpected results when IPv6 addresses are used.

Examples:

```JavaScript
var ip = require('ip');

ip.toBuffer("ffff::172.21.0.0") // Would throw an error, should be <Buffer ff ff 00 00 00 00 00 00 00 00 00 00 ac 15 00 00>
ip.toBuffer("::ffff:172.21.0.0") // Returns <Buffer ac 15 00 00>, should return <Buffer 00 00 00 00 00 00 00 00 00 00 ff ff ac 15 00 00>
ip.toBuffer("::FFFF:172.21.0.0") // Also would throw an error, should be the same as above
ip.isPrivate("::ffff:127.0.0.1") // Returns false, should be true
ip.isLoopback("::ffff:127.0.0.1") // Returns false, should be true
```