### PR TITLE
Issue #42: cidrSubnet() is skipping first/last address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# IP  
-[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  
+# IP
+[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)
 
 IP address utilities for node.js
 
@@ -15,7 +15,7 @@ npm install ip
 ```shell
 git clone https://github.com/indutny/node-ip.git
 ```
-  
+
 ## Usage
 Get your ip address, compare ip addresses, validate ip addresses, etc.
 
@@ -44,8 +44,8 @@ ip.toString(buf, offset, 4);            // '127.0.0.1'
 // subnet information
 ip.subnet('192.168.1.134', '255.255.255.192')
 // { networkAddress: '192.168.1.128',
-//   firstAddress: '192.168.1.129',
-//   lastAddress: '192.168.1.190',
+//   firstAddress: '192.168.1.128',
+//   lastAddress: '192.168.1.191',
 //   broadcastAddress: '192.168.1.191',
 //   subnetMask: '255.255.255.192',
 //   subnetMaskLength: 26,

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -194,12 +194,8 @@ ip.subnet = function subnet(addr, mask) {
 
   return {
     networkAddress: ip.fromLong(networkAddress),
-    firstAddress: numberOfAddresses <= 2 ?
-                    ip.fromLong(networkAddress) :
-                    ip.fromLong(networkAddress + 1),
-    lastAddress: numberOfAddresses <= 2 ?
-                    ip.fromLong(networkAddress + numberOfAddresses - 1) :
-                    ip.fromLong(networkAddress + numberOfAddresses - 2),
+    firstAddress: ip.fromLong(networkAddress),
+    lastAddress: ip.fromLong(networkAddress + numberOfAddresses - 1),
     broadcastAddress: ip.fromLong(networkAddress + numberOfAddresses - 1),
     subnetMask: mask,
     subnetMaskLength: maskLength,

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -104,11 +104,11 @@ describe('IP library for node.js', function() {
     });
 
     it('should compute ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.129');
+      assert.equal(ipv4Subnet.firstAddress, '192.168.1.128');
     });
 
     it('should compute ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.190');
+      assert.equal(ipv4Subnet.lastAddress, '192.168.1.191');
     });
 
     it('should compute ipv4 broadcast address', function() {
@@ -173,11 +173,11 @@ describe('IP library for node.js', function() {
     });
 
     it('should compute an ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.129');
+      assert.equal(ipv4Subnet.firstAddress, '192.168.1.128');
     });
 
     it('should compute an ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.190');
+      assert.equal(ipv4Subnet.lastAddress, '192.168.1.191');
     });
 
     it('should compute an ipv4 broadcast address', function() {


### PR DESCRIPTION
In reference to issue #42, I personally believe that `subnet()` and ` cidrSubmit()` firstAddress and lastAddress should be the first and last address in the subnet range, respectively.

Checking several online subnet calculators (ie. http://mxtoolbox.com/subnetcalculator.aspx) you can easily check that given `192.168.1.134/26` the IP range is `192.168.1.128 - 192.168.1.191`. In the issue #42 you correctly states that the first/last IPs are usually used for network/broadcast address, but it's actually a convention and not widely true anymore (ie. AWS EC2).

NOTE: this change, despite is a fix to me, could actually break some client implementations.