### PR TITLE
Remove function names

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -4,7 +4,7 @@ var ip = exports;
 var Buffer = require('buffer').Buffer;
 var os = require('os');
 
-ip.toBuffer = function toBuffer(ip, buff, offset) {
+ip.toBuffer = function(ip, buff, offset) {
   offset = ~~offset;
 
   var result;
@@ -60,7 +60,7 @@ ip.toBuffer = function toBuffer(ip, buff, offset) {
   return result;
 };
 
-ip.toString = function toString(buff, offset, length) {
+ip.toString = function(buff, offset, length) {
   offset = ~~offset;
   length = length || (buff.length - offset);
 
@@ -88,18 +88,18 @@ var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
 var ipv6Regex =
     /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
 
-ip.isV4Format = function isV4Format(ip) {
+ip.isV4Format = function(ip) {
   return ipv4Regex.test(ip);
 };
 
-ip.isV6Format = function isV6Format(ip) {
+ip.isV6Format = function(ip) {
   return ipv6Regex.test(ip);
 };
 function _normalizeFamily(family) {
   return family ? family.toLowerCase() : 'ipv4';
 }
 
-ip.fromPrefixLen = function fromPrefixLen(prefixlen, family) {
+ip.fromPrefixLen = function(prefixlen, family) {
   if (prefixlen > 32) {
     family = 'ipv6';
   } else {
@@ -125,7 +125,7 @@ ip.fromPrefixLen = function fromPrefixLen(prefixlen, family) {
   return ip.toString(buff);
 };
 
-ip.mask = function mask(addr, mask) {
+ip.mask = function(addr, mask) {
   addr = ip.toBuffer(addr);
   mask = ip.toBuffer(mask);
 
@@ -159,7 +159,7 @@ ip.mask = function mask(addr, mask) {
   return ip.toString(result);
 };
 
-ip.cidr = function cidr(cidrString) {
+ip.cidr = function(cidrString) {
   var cidrParts = cidrString.split('/');
 
   var addr = cidrParts[0];
@@ -171,7 +171,7 @@ ip.cidr = function cidr(cidrString) {
   return ip.mask(addr, mask);
 };
 
-ip.subnet = function subnet(addr, mask) {
+ip.subnet = function(addr, mask) {
   var networkAddress = ip.toLong(ip.mask(addr, mask));
 
   // Calculate the mask's length.
@@ -212,7 +212,7 @@ ip.subnet = function subnet(addr, mask) {
   };
 };
 
-ip.cidrSubnet = function cidrSubnet(cidrString) {
+ip.cidrSubnet = function(cidrString) {
   var cidrParts = cidrString.split('/');
 
   var addr = cidrParts[0];
@@ -224,7 +224,7 @@ ip.cidrSubnet = function cidrSubnet(cidrString) {
   return ip.subnet(addr, mask);
 };
 
-ip.not = function not(addr) {
+ip.not = function(addr) {
   var buff = ip.toBuffer(addr);
   for (var i = 0; i < buff.length; i++) {
     buff[i] = 0xff ^ buff[i];
@@ -232,7 +232,7 @@ ip.not = function not(addr) {
   return ip.toString(buff);
 };
 
-ip.or = function or(a, b) {
+ip.or = function(a, b) {
   a = ip.toBuffer(a);
   b = ip.toBuffer(b);
 
@@ -261,7 +261,7 @@ ip.or = function or(a, b) {
   }
 };
 
-ip.isEqual = function isEqual(a, b) {
+ip.isEqual = function(a, b) {
   a = ip.toBuffer(a);
   b = ip.toBuffer(b);
 
@@ -295,7 +295,7 @@ ip.isEqual = function isEqual(a, b) {
   return true;
 };
 
-ip.isPrivate = function isPrivate(addr) {
+ip.isPrivate = function(addr) {
   return /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/
       .test(addr) ||
     /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
@@ -309,11 +309,11 @@ ip.isPrivate = function isPrivate(addr) {
     /^::$/.test(addr);
 };
 
-ip.isPublic = function isPublic(addr) {
+ip.isPublic = function(addr) {
   return !ip.isPrivate(addr);
 };
 
-ip.isLoopback = function isLoopback(addr) {
+ip.isLoopback = function(addr) {
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
       .test(addr) ||
     /^fe80::1$/.test(addr) ||
@@ -321,7 +321,7 @@ ip.isLoopback = function isLoopback(addr) {
     /^::$/.test(addr);
 };
 
-ip.loopback = function loopback(family) {
+ip.loopback = function(family) {
   //
   // Default to `ipv4`
   //
@@ -349,7 +349,7 @@ ip.loopback = function loopback(family) {
 //   * 'private': the first private ip address of family.
 //   * undefined: First address with `ipv4` or loopback address `127.0.0.1`.
 //
-ip.address = function address(name, family) {
+ip.address = function(name, family) {
   var interfaces = os.networkInterfaces();
   var all;
 
@@ -395,7 +395,7 @@ ip.address = function address(name, family) {
   return !all.length ? ip.loopback(family) : all[0];
 };
 
-ip.toLong = function toInt(ip) {
+ip.toLong = function(ip) {
   var ipl = 0;
   ip.split('.').forEach(function(octet) {
     ipl <<= 8;
@@ -404,7 +404,7 @@ ip.toLong = function toInt(ip) {
   return(ipl >>> 0);
 };
 
-ip.fromLong = function fromInt(ipl) {
+ip.fromLong = function(ipl) {
   return ((ipl >>> 24) + '.' +
       (ipl >> 16 & 255) + '.' +
       (ipl >> 8 & 255) + '.' +


### PR DESCRIPTION
Named function 'mask' causes strict mode violation in Safari:

SyntaxError: Cannot declare a parameter named 'mask' as it shadows
the name of a strict mode function.

Fixes #46