### PR TITLE
[fix] Check against full fc00::/7 ipv6 private space

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -303,7 +303,7 @@ ip.isPrivate = function(addr) {
       .test(addr) ||
     /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
     /^(::f{4}:)?169\.254\.([0-9]{1,3})\.([0-9]{1,3})$/.test(addr) ||
-    /^fc00:/i.test(addr) ||
+    /^f[cd][0-9a-f]{2}:/i.test(addr) ||
     /^fe80:/i.test(addr) ||
     /^::1$/.test(addr) ||
     /^::$/.test(addr);

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -270,6 +270,7 @@ describe('IP library for node.js', function() {
     });
 
     it('should check if an address is from a private IPv6 network', function() {
+      assert.equal(ip.isPrivate('fd12:3456:789a:1::1'), true);
       assert.equal(ip.isPrivate('fe80::f2de:f1ff:fe3f:307e'), true);
     });
 


### PR DESCRIPTION
My understanding from reading rfc4193 is that IPv6 private space is fc00::/7
That would be FC00:0000:0000:0000:0000:0000:0000:0000 - FDFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF

See: https://tools.ietf.org/html/rfc4193#section-3