### PR TITLE
allow to get multiple addresses assign to interface

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -340,16 +340,21 @@ ip.loopback = function(family) {
 //      of the network interface.
 // #### @family {ipv4|ipv6} **Optional** IP family of the address (defaults
 //      to ipv4).
+// #### @multiple {Boolean} **Optional** Returns all addresses with for given
+//      name and family if true
 //
-// Returns the address for the network interface on the current system with
-// the specified `name`:
+// Returns the address (or an array of addresses if `multiply` for the network
+// interface on the current system with the specified `name`:
 //   * String: First `family` address of the interface.
 //             If not found see `undefined`.
 //   * 'public': the first public ip address of family.
 //   * 'private': the first private ip address of family.
 //   * undefined: First address with `ipv4` or loopback address `127.0.0.1`.
-//
-ip.address = function(name, family) {
+
+ip.address = function(name, family, multiple) {
+  // if (multiple) {
+  //   return [];
+  // }
   var interfaces = os.networkInterfaces();
   var all;
 
@@ -360,7 +365,7 @@ ip.address = function(name, family) {
 
   //
   // If a specific network interface has been named,
-  // return the address.
+  // return the address (or addresses if `multiple`).
   //
   if (name && name !== 'private' && name !== 'public') {
     var res = interfaces[name].filter(function(details) {
@@ -369,7 +374,9 @@ ip.address = function(name, family) {
     });
     if (res.length === 0)
       return undefined;
-    return res[0].address;
+    return multiple ?
+        res.map(function (a) { return a.address; }) :
+        res[0].address;
   }
 
   var all = Object.keys(interfaces).map(function (nic) {
@@ -388,11 +395,16 @@ ip.address = function(name, family) {
       return name === 'public' ? ip.isPrivate(details.address) :
           ip.isPublic(details.address);
     });
+    return multiple ?
+        addresses.map(function (a) { return a.address; }) :
+        addresses.length ? addresses[0].address : undefined;
+  });
 
-    return addresses.length ? addresses[0].address : undefined;
-  }).filter(Boolean);
+  all = [].concat.apply([], all).filter(Boolean);
 
-  return !all.length ? ip.loopback(family) : all[0];
+  return multiple ?
+      !all.length ? [ ip.loopback(family) ] : all :
+      !all.length ? ip.loopback(family) : all[0];
 };
 
 ip.toLong = function(ip) {
@@ -410,3 +422,4 @@ ip.fromLong = function(ipl) {
       (ipl >> 8 & 255) + '.' +
       (ipl & 255) );
 };
+

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -36,9 +36,9 @@ describe('IP library for node.js', function() {
       assert(/(00){15,15}01/.test(buf.toString('hex', offset, offset + 16)));
       assert.equal(ip.toString(buf, offset, 16), '::1');
       assert.equal(ip.toString(ip.toBuffer('1::', buf, offset),
-                               offset, 16), '1::');
+        offset, 16), '1::');
       assert.equal(ip.toString(ip.toBuffer('abcd::dcba', buf, offset),
-                               offset, 16), 'abcd::dcba');
+        offset, 16), 'abcd::dcba');
     });
 
     it('should convert to buffer IPv6 mapped IPv4 address', function() {
@@ -80,11 +80,11 @@ describe('IP library for node.js', function() {
     });
     it('should or bits in ipv6 addresses', function() {
       assert.equal(ip.or('::ff', '::abcd:dcba:abcd:dcba'),
-                   '::abcd:dcba:abcd:dcff');
+        '::abcd:dcba:abcd:dcff');
     });
     it('should or bits in mixed addresses', function() {
       assert.equal(ip.or('0.0.0.255', '::abcd:dcba:abcd:dcba'),
-                   '::abcd:dcba:abcd:dcff');
+        '::abcd:dcba:abcd:dcff');
     });
   });
 
@@ -315,14 +315,14 @@ describe('IP library for node.js', function() {
       });
     });
 
-    describe('127.8.8.8', function () {
-      it('should respond with true', function () {
+    describe('127.8.8.8', function() {
+      it('should respond with true', function() {
         assert.ok(ip.isLoopback('127.8.8.8'))
       });
     });
 
-    describe('8.8.8.8', function () {
-      it('should respond with false', function () {
+    describe('8.8.8.8', function() {
+      it('should respond with false', function() {
         assert.equal(ip.isLoopback('8.8.8.8'), false);
       });
     });
@@ -359,6 +359,13 @@ describe('IP library for node.js', function() {
           it('should respond with a private ip', function() {
             assert.ok(ip.isPrivate(ip.address('private', family)));
           });
+          it('should respond with a private ip addresses', function() {
+            var addresses = ip.address('private', family, true);
+            assert.ok(Array.isArray(addresses));
+            addresses.forEach(function(a) {
+              assert.ok(ip.isPrivate(a));
+            });
+          });
         });
       });
     });
@@ -373,6 +380,14 @@ describe('IP library for node.js', function() {
               var addr = ip.address(nic, family);
               assert.ok(!addr || net.isIPv4(addr));
             });
+
+            it('should respond with multiple ipv4 addresses', function() {
+              var addresses = ip.address(nic, family, true);
+              assert.ok(Array.isArray(addresses));
+              assert.ok(addresses.length === 0 || addresses.every(function(a) {
+                return net.isIPv4(a);
+              }));
+            });
           });
         });
 
@@ -380,6 +395,14 @@ describe('IP library for node.js', function() {
           it('should respond with an ipv6 address', function() {
             var addr = ip.address(nic, 'ipv6');
             assert.ok(!addr || net.isIPv6(addr));
+          });
+
+          it('should respond with multiple ipv6 addresses', function() {
+            var addresses = ip.address(nic, 'ipv6', true);
+            assert.ok(Array.isArray(addresses));
+            assert.ok(addresses.length === 0 || addresses.every(function(a) {
+              return net.isIPv6(a);
+            }));
           });
         })
       });


### PR DESCRIPTION
Extend 'address' function so it can be used to return all interface addresses.

closes #70.