### PR TITLE
address(name): name not found should respond with undefined

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -367,6 +367,8 @@ ip.address = function(name, family) {
   // return the address.
   //
   if (name && name !== 'private' && name !== 'public') {
+    if (!interfaces[name])
+      return undefined;
     var res = interfaces[name].filter(function(details) {
       var itemFamily = details.family.toLowerCase();
       return itemFamily === family;

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -358,6 +358,12 @@ describe('IP library for node.js', function() {
       });
     });
 
+    describe('not found', function() {
+      it('should respond with a undefined', function() {
+        assert.equal(ip.address('not found'), undefined);
+      });
+    });
+
     describe('private', function() {
       [ undefined, 'ipv4', 'ipv6' ].forEach(function(family) {
         describe(family, function() {


### PR DESCRIPTION
now ip.address('not found') throw TypeError: Cannot read property 'filter' of undefined.
I think should respond with undefined.