### PR TITLE
bugfix: ip.address() simple logic error

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -388,9 +388,9 @@ ip.address = function(name, family) {
       } else if (!name) {
         return true;
       }
-
-      return name === 'public' ? ip.isPrivate(details.address) :
-          ip.isPublic(details.address);
+      
+      return name === 'public' ? ip.isPublic(details.address) :
+          ip.isPrivate(details.address);
     });
 
     return addresses.length ? addresses[0].address : undefined;


### PR DESCRIPTION
send public but return private ip address
```js
return name === 'public' ? ip.isPrivate(details.address) : ip.isPublic(details.address);
```

test code will never assert when there is no public ip in my test env
```js
describe('undefined', function() {
  it('should respond with a private ip', function() {
    assert.ok(ip.isPrivate(ip.address()));
  });
});
```