### PR TITLE
Sort interfaces by priority when searching an IP address

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -376,7 +376,25 @@ ip.address = function(name, family) {
     return res[0].address;
   }
 
-  var all = Object.keys(interfaces).map(function (nic) {
+  function priority (name) {
+    if (name.startsWith('en') || name.startsWith('eth')) {
+      return 0;
+    }
+    if (name.startsWith('wlan')) {
+      return 1;
+    }
+
+    return 2;
+  }
+
+  var sortedInterfaces = Object.keys(interfaces).sort(function(a, b) {
+    a = priority(a);
+    b = priority(b);
+
+    return a - b;
+  });
+
+  var all = sortedInterfaces.map(function (nic) {
     //
     // Note: name will only be `public` or `private`
     // when this is called.


### PR DESCRIPTION
Currently `ip.address()` will search in all interfaces given by `os.networkInterfaces()`. This needs to take into account that multiple valid IPs can be found, and some of them may be preferable to others, depending on the type of network adapter.

For example, when `os.networkInterfaces()` returns:
```
{
  lo0:
   [ { address: '127.0.0.1',
       netmask: '255.0.0.0',
       family: 'IPv4',
       mac: '00:00:00:00:00:00',
       internal: true },
     { address: '10.200.10.1',
       netmask: '255.255.255.0',
       family: 'IPv4',
       mac: '00:00:00:00:00:00',
       internal: true } ],
  en0:
   [ { address: 'fe80::d9:8c22:6588:6d41',
       netmask: 'ffff:ffff:ffff:ffff::',
       family: 'IPv6',
       mac: '06:00:00:06:0e:00',
       scopeid: 4,
       internal: false },
     { address: '192.168.1.72',
       netmask: '255.255.255.0',
       family: 'IPv4',
       mac: '06:00:00:06:0e:00',
       internal: false } ]
}
```

The proper value for `ip.address()` should be `192.168.1.72`, and NOT `10.200.10.1`, as currently returned by node v8.1.3 on macOS 10.12.6.