### PR TITLE
add eslint, support node>=4.0.0, update document, fix minor bugs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "extends": "standard",
+    "env": {
+        "node": true,
+        "mocha": true
+    },
+    "rules": {
+        "new-cap": ["error", { "properties": false }]
+    }
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
+  #- "0.8"
+  #- "0.10"
+  #- "0.12"
   - "4"
   - "6"
+  - "8"
 
 before_install:
   - travis_retry npm install -g npm@2.14.5

--- a/README.md
+++ b/README.md
@@ -22,8 +22,22 @@ Get your ip address, compare ip addresses, validate ip addresses, etc.
 ```js
 var ip = require('ip');
 
+/**
+ *  @param {string} name **Optional** {'public'|'private'},
+ *   Name or security of the network interface like "Docket" | "Wi-Fi",
+ *   if neme set `undefined` return first address of the interface with `ipv4` or loopback address,
+ *   if name set `public` return first public ip address,
+ *   or if name set `private` return first public ip address.
+ *  @param   {string} family **Optional** {ipv4|ipv6}  IP family of the address (defaults: ipv4).
+ *  @returns {string} Returns the address for the network interface on the current system.
+ */
 ip.address() // my ip address
-ip.isEqual('::1', '::0:1'); // true
+ip.address('Wi-Fi') // Obtain Wi-Fi IPV4 address
+ip.address('vEthernet (DockerNAT)') // Obtain DocketNAt IPV4 address
+ip.address('private') // Obtain private IPV4 address
+ip.address('public','ipv6') // Obtain public IPV6 address
+
+ip.isEqual('::1', '::0:1') // true
 ip.toBuffer('127.0.0.1') // Buffer([127, 0, 0, 1])
 ip.toString(new Buffer([127, 0, 0, 1])) // 127.0.0.1
 ip.fromPrefixLen(24) // 255.255.255.0
@@ -33,7 +47,7 @@ ip.not('255.255.255.0') // 0.0.0.255
 ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
 ip.isV4Format('127.0.0.1'); // true
-ip.isV6Format('::ffff:127.0.0.1'); // true
+ip.isV6Format('::ffff:127.0.0.1') // true
 
 // operate on buffers in-place
 var buf = new Buffer(128);
@@ -60,8 +74,8 @@ ip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true
 
 
 // ipv4 long conversion
-ip.toLong('127.0.0.1'); // 2130706433
-ip.fromLong(2130706433); // '127.0.0.1'
+ip.toLong('127.0.0.1') // 2130706433
+ip.fromLong(2130706433) // '127.0.0.1'
 ```
 
 ### License

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1,307 +1,306 @@
-'use strict';
+'use strict'
 
-var ip = exports;
-var Buffer = require('buffer').Buffer;
-var os = require('os');
+const ip = exports
+const Buffer = require('buffer').Buffer
+const os = require('os')
+const net = require('net')
 
-ip.toBuffer = function(ip, buff, offset) {
-  offset = ~~offset;
+ip.toBuffer = function (ip, buff, offset) {
+  offset = ~~offset
 
-  var result;
+  let result
 
   if (this.isV4Format(ip)) {
-    result = buff || new Buffer(offset + 4);
-    ip.split(/\./g).map(function(byte) {
-      result[offset++] = parseInt(byte, 10) & 0xff;
-    });
+    result = buff || new Buffer.alloc(offset + 4)
+    ip.split(/\./g).map(function (byte) {
+      result[offset++] = parseInt(byte, 10) & 0xff
+    })
   } else if (this.isV6Format(ip)) {
-    var sections = ip.split(':', 8);
+    const sections = ip.split(':', 8)
 
-    var i;
+    let i
     for (i = 0; i < sections.length; i++) {
-      var isv4 = this.isV4Format(sections[i]);
-      var v4Buffer;
+      const isv4 = this.isV4Format(sections[i])
+      let v4Buffer
 
       if (isv4) {
-        v4Buffer = this.toBuffer(sections[i]);
-        sections[i] = v4Buffer.slice(0, 2).toString('hex');
+        v4Buffer = this.toBuffer(sections[i])
+        sections[i] = v4Buffer.slice(0, 2).toString('hex')
       }
 
       if (v4Buffer && ++i < 8) {
-        sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'));
+        sections.splice(i, 0, v4Buffer.slice(2, 4).toString('hex'))
       }
     }
 
     if (sections[0] === '') {
-      while (sections.length < 8) sections.unshift('0');
+      while (sections.length < 8) sections.unshift('0')
     } else if (sections[sections.length - 1] === '') {
-      while (sections.length < 8) sections.push('0');
+      while (sections.length < 8) sections.push('0')
     } else if (sections.length < 8) {
       for (i = 0; i < sections.length && sections[i] !== ''; i++);
-      var argv = [ i, 1 ];
+      let argv = [ i, 1 ]
       for (i = 9 - sections.length; i > 0; i--) {
-        argv.push('0');
+        argv.push('0')
       }
-      sections.splice.apply(sections, argv);
+      sections.splice.apply(sections, argv)
     }
 
-    result = buff || new Buffer(offset + 16);
+    result = buff || new Buffer.alloc(offset + 16)
     for (i = 0; i < sections.length; i++) {
-      var word = parseInt(sections[i], 16);
-      result[offset++] = (word >> 8) & 0xff;
-      result[offset++] = word & 0xff;
+      const word = parseInt(sections[i], 16)
+      result[offset++] = (word >> 8) & 0xff
+      result[offset++] = word & 0xff
     }
   }
 
   if (!result) {
-    throw Error('Invalid ip address: ' + ip);
+    throw Error('Invalid ip address: ' + ip)
   }
 
-  return result;
-};
-
-ip.toString = function(buff, offset, length) {
-  offset = ~~offset;
-  length = length || (buff.length - offset);
-
-  var result = [];
-  if (length === 4) {
-    // IPv4
-    for (var i = 0; i < length; i++) {
-      result.push(buff[offset + i]);
-    }
-    result = result.join('.');
-  } else if (length === 16) {
-    // IPv6
-    for (var i = 0; i < length; i += 2) {
-      result.push(buff.readUInt16BE(offset + i).toString(16));
-    }
-    result = result.join(':');
-    result = result.replace(/(^|:)0(:0)*:0(:|$)/, '$1::$3');
-    result = result.replace(/:{3,4}/, '::');
-  }
-
-  return result;
-};
-
-var ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
-var ipv6Regex =
-    /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
-
-ip.isV4Format = function(ip) {
-  return ipv4Regex.test(ip);
-};
-
-ip.isV6Format = function(ip) {
-  return ipv6Regex.test(ip);
-};
-function _normalizeFamily(family) {
-  return family ? family.toLowerCase() : 'ipv4';
+  return result
 }
 
-ip.fromPrefixLen = function(prefixlen, family) {
-  if (prefixlen > 32) {
-    family = 'ipv6';
-  } else {
-    family = _normalizeFamily(family);
-  }
+ip.toString = function (buff, offset, length) {
+  offset = ~~offset
+  length = length || (buff.length - offset)
 
-  var len = 4;
-  if (family === 'ipv6') {
-    len = 16;
-  }
-  var buff = new Buffer(len);
-
-  for (var i = 0, n = buff.length; i < n; ++i) {
-    var bits = 8;
-    if (prefixlen < 8) {
-      bits = prefixlen;
+  let result = []
+  if (length === 4) {
+    // IPv4
+    for (let i = 0; i < length; i++) {
+      result.push(buff[offset + i])
     }
-    prefixlen -= bits;
-
-    buff[i] = ~(0xff >> bits) & 0xff;
+    result = result.join('.')
+  } else if (length === 16) {
+    // IPv6
+    for (let i = 0; i < length; i += 2) {
+      result.push(buff.readUInt16BE(offset + i).toString(16))
+    }
+    result = result.join(':')
+    result = result.replace(/(^|:)0(:0)*:0(:|$)/, '$1::$3')
+    result = result.replace(/:{3,4}/, '::')
   }
 
-  return ip.toString(buff);
-};
+  return result
+}
 
-ip.mask = function(addr, mask) {
-  addr = ip.toBuffer(addr);
-  mask = ip.toBuffer(mask);
+ip.isV4Format = function (ip) {
+  // net.isIPv4 Added in: v0.3.0
+  // Returns true if input is a version 4 IP address, otherwise returns false.
+  return net.isIPv4(ip)
+}
 
-  var result = new Buffer(Math.max(addr.length, mask.length));
+ip.isV6Format = function (ip) {
+  // net.isIPv4 Added in: v0.3.0
+  // Returns true if input is a version 6 IP address, otherwise returns false.
+  return net.isIPv6(ip)
+}
 
-  var i = 0;
+function _normalizeFamily (family) {
+  return family ? family.toLowerCase() : 'ipv4'
+}
+
+ip.fromPrefixLen = function (prefixlen, family) {
+  if (prefixlen > 32) {
+    family = 'ipv6'
+  } else {
+    family = _normalizeFamily(family)
+  }
+
+  let len = 4
+  if (family === 'ipv6') {
+    len = 16
+  }
+  const buff = new Buffer.alloc(len)
+
+  for (let i = 0, n = buff.length; i < n; ++i) {
+    let bits = 8
+    if (prefixlen < 8) {
+      bits = prefixlen
+    }
+    prefixlen -= bits
+
+    buff[i] = ~(0xff >> bits) & 0xff
+  }
+
+  return ip.toString(buff)
+}
+
+ip.mask = function (addr, mask) {
+  addr = ip.toBuffer(addr)
+  mask = ip.toBuffer(mask)
+
+  const result = new Buffer.alloc(Math.max(addr.length, mask.length))
+
+  let i = 0
   // Same protocol - do bitwise and
   if (addr.length === mask.length) {
     for (i = 0; i < addr.length; i++) {
-      result[i] = addr[i] & mask[i];
+      result[i] = addr[i] & mask[i]
     }
   } else if (mask.length === 4) {
     // IPv6 address and IPv4 mask
     // (Mask low bits)
     for (i = 0; i < mask.length; i++) {
-      result[i] = addr[addr.length - 4  + i] & mask[i];
+      result[i] = addr[addr.length - 4 + i] & mask[i]
     }
   } else {
     // IPv6 mask and IPv4 addr
-    for (var i = 0; i < result.length - 6; i++) {
-      result[i] = 0;
+    for (let i = 0; i < result.length - 6; i++) {
+      result[i] = 0
     }
 
     // ::ffff:ipv4
-    result[10] = 0xff;
-    result[11] = 0xff;
+    result[10] = 0xff
+    result[11] = 0xff
     for (i = 0; i < addr.length; i++) {
-      result[i + 12] = addr[i] & mask[i + 12];
+      result[i + 12] = addr[i] & mask[i + 12]
     }
-    i = i + 12;
+    i = i + 12
   }
-  for (; i < result.length; i++)
-    result[i] = 0;
+  for (; i < result.length; i++) { result[i] = 0 }
 
-  return ip.toString(result);
-};
+  return ip.toString(result)
+}
 
-ip.cidr = function(cidrString) {
-  var cidrParts = cidrString.split('/');
+ip.cidr = function (cidrString) {
+  const cidrParts = cidrString.split('/')
 
-  var addr = cidrParts[0];
-  if (cidrParts.length !== 2)
-    throw new Error('invalid CIDR subnet: ' + addr);
+  const addr = cidrParts[0]
+  if (cidrParts.length !== 2) { throw new Error('invalid CIDR subnet: ' + addr) }
 
-  var mask = ip.fromPrefixLen(parseInt(cidrParts[1], 10));
+  const mask = ip.fromPrefixLen(parseInt(cidrParts[1], 10))
 
-  return ip.mask(addr, mask);
-};
+  return ip.mask(addr, mask)
+}
 
-ip.subnet = function(addr, mask) {
-  var networkAddress = ip.toLong(ip.mask(addr, mask));
+ip.subnet = function (addr, mask) {
+  const networkAddress = ip.toLong(ip.mask(addr, mask))
 
   // Calculate the mask's length.
-  var maskBuffer = ip.toBuffer(mask);
-  var maskLength = 0;
+  const maskBuffer = ip.toBuffer(mask)
+  let maskLength = 0
 
-  for (var i = 0; i < maskBuffer.length; i++) {
+  for (let i = 0; i < maskBuffer.length; i++) {
     if (maskBuffer[i] === 0xff) {
-      maskLength += 8;
+      maskLength += 8
     } else {
-      var octet = maskBuffer[i] & 0xff;
+      let octet = maskBuffer[i] & 0xff
       while (octet) {
-        octet = (octet << 1) & 0xff;
-        maskLength++;
+        octet = (octet << 1) & 0xff
+        maskLength++
       }
     }
   }
 
-  var numberOfAddresses = Math.pow(2, 32 - maskLength);
+  const numberOfAddresses = Math.pow(2, 32 - maskLength)
 
   return {
     networkAddress: ip.fromLong(networkAddress),
-    firstAddress: numberOfAddresses <= 2 ?
-                    ip.fromLong(networkAddress) :
-                    ip.fromLong(networkAddress + 1),
-    lastAddress: numberOfAddresses <= 2 ?
-                    ip.fromLong(networkAddress + numberOfAddresses - 1) :
-                    ip.fromLong(networkAddress + numberOfAddresses - 2),
+    firstAddress: numberOfAddresses <= 2
+      ? ip.fromLong(networkAddress)
+      : ip.fromLong(networkAddress + 1),
+    lastAddress: numberOfAddresses <= 2
+      ? ip.fromLong(networkAddress + numberOfAddresses - 1)
+      : ip.fromLong(networkAddress + numberOfAddresses - 2),
     broadcastAddress: ip.fromLong(networkAddress + numberOfAddresses - 1),
     subnetMask: mask,
     subnetMaskLength: maskLength,
-    numHosts: numberOfAddresses <= 2 ?
-                numberOfAddresses : numberOfAddresses - 2,
+    numHosts: numberOfAddresses <= 2
+      ? numberOfAddresses : numberOfAddresses - 2,
     length: numberOfAddresses,
-    contains: function(other) {
-      return networkAddress === ip.toLong(ip.mask(other, mask));
+    contains: function (other) {
+      return networkAddress === ip.toLong(ip.mask(other, mask))
     }
-  };
-};
-
-ip.cidrSubnet = function(cidrString) {
-  var cidrParts = cidrString.split('/');
-
-  var addr = cidrParts[0];
-  if (cidrParts.length !== 2)
-    throw new Error('invalid CIDR subnet: ' + addr);
-
-  var mask = ip.fromPrefixLen(parseInt(cidrParts[1], 10));
-
-  return ip.subnet(addr, mask);
-};
-
-ip.not = function(addr) {
-  var buff = ip.toBuffer(addr);
-  for (var i = 0; i < buff.length; i++) {
-    buff[i] = 0xff ^ buff[i];
   }
-  return ip.toString(buff);
-};
+}
 
-ip.or = function(a, b) {
-  a = ip.toBuffer(a);
-  b = ip.toBuffer(b);
+ip.cidrSubnet = function (cidrString) {
+  const cidrParts = cidrString.split('/')
+
+  const addr = cidrParts[0]
+  if (cidrParts.length !== 2) { throw new Error('invalid CIDR subnet: ' + addr) }
+
+  const mask = ip.fromPrefixLen(parseInt(cidrParts[1], 10))
+
+  return ip.subnet(addr, mask)
+}
+
+ip.not = function (addr) {
+  const buff = ip.toBuffer(addr)
+  for (let i = 0; i < buff.length; i++) {
+    buff[i] = 0xff ^ buff[i]
+  }
+  return ip.toString(buff)
+}
+
+ip.or = function (a, b) {
+  a = ip.toBuffer(a)
+  b = ip.toBuffer(b)
 
   // same protocol
   if (a.length === b.length) {
-    for (var i = 0; i < a.length; ++i) {
-      a[i] |= b[i];
+    for (let i = 0; i < a.length; ++i) {
+      a[i] |= b[i]
     }
-    return ip.toString(a);
+    return ip.toString(a)
 
   // mixed protocols
   } else {
-    var buff = a;
-    var other = b;
+    let buff = a
+    let other = b
     if (b.length > a.length) {
-      buff = b;
-      other = a;
+      buff = b
+      other = a
     }
 
-    var offset = buff.length - other.length;
-    for (var i = offset; i < buff.length; ++i) {
-      buff[i] |= other[i - offset];
+    const offset = buff.length - other.length
+    for (let i = offset; i < buff.length; ++i) {
+      buff[i] |= other[i - offset]
     }
 
-    return ip.toString(buff);
+    return ip.toString(buff)
   }
-};
+}
 
-ip.isEqual = function(a, b) {
-  a = ip.toBuffer(a);
-  b = ip.toBuffer(b);
+ip.isEqual = function (a, b) {
+  a = ip.toBuffer(a)
+  b = ip.toBuffer(b)
 
   // Same protocol
   if (a.length === b.length) {
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false
     }
-    return true;
+    return true
   }
 
   // Swap
   if (b.length === 4) {
-    var t = b;
-    b = a;
-    a = t;
+    const t = b
+    b = a
+    a = t
   }
 
   // a - IPv4, b - IPv6
-  for (var i = 0; i < 10; i++) {
-    if (b[i] !== 0) return false;
+  for (let i = 0; i < 10; i++) {
+    if (b[i] !== 0) return false
   }
 
-  var word = b.readUInt16BE(10);
-  if (word !== 0 && word !== 0xffff) return false;
+  const word = b.readUInt16BE(10)
+  if (word !== 0 && word !== 0xffff) return false
 
-  for (var i = 0; i < 4; i++) {
-    if (a[i] !== b[i + 12]) return false;
+  for (let i = 0; i < 4; i++) {
+    if (a[i] !== b[i + 12]) return false
   }
 
-  return true;
-};
+  return true
+}
 
-ip.isPrivate = function(addr) {
+ip.isPrivate = function (addr) {
   return /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i
-      .test(addr) ||
+    .test(addr) ||
     /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
     /^(::f{4}:)?172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})$/i
       .test(addr) ||
@@ -310,107 +309,98 @@ ip.isPrivate = function(addr) {
     /^f[cd][0-9a-f]{2}:/i.test(addr) ||
     /^fe80:/i.test(addr) ||
     /^::1$/.test(addr) ||
-    /^::$/.test(addr);
-};
+    /^::$/.test(addr)
+}
 
-ip.isPublic = function(addr) {
-  return !ip.isPrivate(addr);
-};
+ip.isPublic = function (addr) {
+  return !ip.isPrivate(addr)
+}
 
-ip.isLoopback = function(addr) {
+ip.isLoopback = function (addr) {
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
-      .test(addr) ||
+    .test(addr) ||
     /^fe80::1$/.test(addr) ||
     /^::1$/.test(addr) ||
-    /^::$/.test(addr);
-};
+    /^::$/.test(addr)
+}
 
-ip.loopback = function(family) {
+ip.loopback = function (family) {
   //
   // Default to `ipv4`
   //
-  family = _normalizeFamily(family);
+  family = _normalizeFamily(family)
 
   if (family !== 'ipv4' && family !== 'ipv6') {
-    throw new Error('family must be ipv4 or ipv6');
+    throw new Error('family must be ipv4 or ipv6')
   }
 
-  return family === 'ipv4' ? '127.0.0.1' : 'fe80::1';
-};
+  return family === 'ipv4' ? '127.0.0.1' : 'fe80::1'
+}
 
-//
-// ### function address (name, family)
-// #### @name {string|'public'|'private'} **Optional** Name or security
-//      of the network interface.
-// #### @family {ipv4|ipv6} **Optional** IP family of the address (defaults
-//      to ipv4).
-//
-// Returns the address for the network interface on the current system with
-// the specified `name`:
-//   * String: First `family` address of the interface.
-//             If not found see `undefined`.
-//   * 'public': the first public ip address of family.
-//   * 'private': the first private ip address of family.
-//   * undefined: First address with `ipv4` or loopback address `127.0.0.1`.
-//
-ip.address = function(name, family) {
-  var interfaces = os.networkInterfaces();
-  var all;
-
+/**
+ *  @param {string} name **Optional** {'public'|'private'},
+ *   Name or security of the network interface like "Docket" | "Wi-Fi",
+ *   if neme set `undefined` return first address of the interface with `ipv4` or loopback address,
+ *   if name set `public` return first public ip address,
+ *   or if name set `private` return first public ip address.
+ *  @param   {string} family **Optional** {ipv4|ipv6}  IP family of the address (defaults: ipv4).
+ *  @returns {string} Returns the address for the network interface on the current system.
+ */
+ip.address = function (name, family) {
+  const interfaces = os.networkInterfaces()
   //
   // Default to `ipv4`
   //
-  family = _normalizeFamily(family);
+  family = _normalizeFamily(family)
 
   //
   // If a specific network interface has been named,
   // return the address.
   //
   if (name && name !== 'private' && name !== 'public') {
-    var res = interfaces[name].filter(function(details) {
-      var itemFamily = details.family.toLowerCase();
-      return itemFamily === family;
-    });
-    if (res.length === 0)
-      return undefined;
-    return res[0].address;
+    const res = interfaces[name].filter(function (details) {
+      const itemFamily = details.family.toLowerCase()
+      return itemFamily === family
+    })
+    if (res.length === 0) { return undefined }
+    return res[0].address
   }
 
-  var all = Object.keys(interfaces).map(function (nic) {
+  const all = Object.keys(interfaces).map(function (nic) {
     //
     // Note: name will only be `public` or `private`
     // when this is called.
     //
-    var addresses = interfaces[nic].filter(function (details) {
-      details.family = details.family.toLowerCase();
+    const addresses = interfaces[nic].filter(function (details) {
+      details.family = details.family.toLowerCase()
       if (details.family !== family || ip.isLoopback(details.address)) {
-        return false;
+        return false
       } else if (!name) {
-        return true;
+        return true
       }
 
-      return name === 'public' ? ip.isPrivate(details.address) :
-          ip.isPublic(details.address);
-    });
+      return name === 'public' ? ip.isPrivate(details.address)
+        : ip.isPublic(details.address)
+    })
 
-    return addresses.length ? addresses[0].address : undefined;
-  }).filter(Boolean);
+    return addresses.length ? addresses[0].address : undefined
+  }).filter(Boolean)
 
-  return !all.length ? ip.loopback(family) : all[0];
-};
+  return !all.length ? ip.loopback(family) : all[0]
+}
 
-ip.toLong = function(ip) {
-  var ipl = 0;
-  ip.split('.').forEach(function(octet) {
-    ipl <<= 8;
-    ipl += parseInt(octet);
-  });
-  return(ipl >>> 0);
-};
+ip.toLong = function (ip) {
+  let ipl = 0
+  ip.split('.').forEach(function (octet) {
+    ipl <<= 8
+    ipl += parseInt(octet)
+  })
+  return (ipl >>> 0)
+}
 
-ip.fromLong = function(ipl) {
+ip.fromLong = function (ipl) {
   return ((ipl >>> 24) + '.' +
       (ipl >> 16 & 255) + '.' +
       (ipl >> 8 & 255) + '.' +
-      (ipl & 255) );
-};
+      (ipl & 255))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2330 @@
+{
+  "name": "ip",
+  "version": "1.1.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
+      "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
+      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+      "dev": true,
+      "optional": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
+      "optional": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true,
+      "optional": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true,
+      "optional": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "optional": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "optional": true
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true,
+      "optional": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
+      "integrity": "sha1-Suc/Gu6Nb89ITxoc53zmUdm38Mk=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "dev": true,
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
+      "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+          "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
+      "integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^4.0.2",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "dev": true
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "optional": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.5.1.tgz",
+      "integrity": "sha1-HezR8ipLMNrn02N5nsYkz0DMAHA=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "optional": true
+    },
+    "har-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "optional": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "optional": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jshint": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+      "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2",
+        "phantom": "~4.0.1",
+        "phantomjs-prebuilt": "~2.1.7",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x",
+        "unicode-5.2.0": "^0.7.5"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true,
+      "optional": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true,
+      "optional": true
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true,
+      "optional": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.37.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "1.3.2",
+      "resolved": "http://registry.npmjs.org/mocha/-/mocha-1.3.2.tgz",
+      "integrity": "sha1-q5e08eWUK5/k1ENri9nu2g6wHhM=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "debug": "*",
+        "diff": "1.0.2",
+        "growl": "1.5.x",
+        "jade": "0.26.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true,
+      "optional": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "optional": true
+    },
+    "phantom": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+      "integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "phantomjs-prebuilt": "^2.1.16",
+        "split": "^1.0.1",
+        "winston": "^2.4.0"
+      }
+    },
+    "phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true,
+      "optional": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true,
+      "optional": true
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true,
+      "optional": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true,
+      "optional": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true,
+      "optional": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
+      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "optional": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
+      "integrity": "sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.3",
+        "lodash": "^4.17.10",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true,
+      "optional": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true,
+      "optional": true
+    },
+    "unicode-5.2.0": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+      "integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true,
+      "optional": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,21 +1,28 @@
 {
   "name": "ip",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": "Fedor Indutny <fedor@indutny.com>",
   "homepage": "https://github.com/indutny/node-ip",
   "repository": {
     "type": "git",
     "url": "http://github.com/indutny/node-ip.git"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "main": "lib/ip",
   "devDependencies": {
-    "jscs": "^2.1.1",
-    "jshint": "^2.8.0",
-    "mocha": "~1.3.2"
+    "eslint": "^5.7.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "mocha": "^1.3.2"
   },
   "scripts": {
-    "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
-    "fix": "jscs lib/*.js test/*.js --fix"
+    "test": "npm run fix && mocha --reporter spec test/api-test.js",
+    "fix": "eslint  lib/ip.js test/api-test.js --fix"
   },
   "license": "MIT"
 }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1,407 +1,404 @@
-'use strict';
+'use strict'
 
-var ip = require('..');
-var assert = require('assert');
-var net = require('net');
-var os = require('os');
+const ip = require('..')
+const assert = require('assert')
+const net = require('net')
+const os = require('os')
 
-describe('IP library for node.js', function() {
-  describe('toBuffer()/toString() methods', function() {
-    it('should convert to buffer IPv4 address', function() {
-      var buf = ip.toBuffer('127.0.0.1');
-      assert.equal(buf.toString('hex'), '7f000001');
-      assert.equal(ip.toString(buf), '127.0.0.1');
-    });
+describe('IP library for node.js', function () {
+  describe('toBuffer()/toString() methods', function () {
+    it('should convert to buffer IPv4 address', function () {
+      const buf = ip.toBuffer('127.0.0.1')
+      assert.strictEqual(buf.toString('hex'), '7f000001')
+      assert.strictEqual(ip.toString(buf), '127.0.0.1')
+    })
 
-    it('should convert to buffer IPv4 address in-place', function() {
-      var buf = new Buffer(128);
-      var offset = 64;
-      ip.toBuffer('127.0.0.1', buf, offset);
-      assert.equal(buf.toString('hex', offset, offset + 4), '7f000001');
-      assert.equal(ip.toString(buf, offset, 4), '127.0.0.1');
-    });
+    it('should convert to buffer IPv4 address in-place', function () {
+      const buf = new Buffer.alloc(128)
+      const offset = 64
+      ip.toBuffer('127.0.0.1', buf, offset)
+      assert.strictEqual(buf.toString('hex', offset, offset + 4), '7f000001')
+      assert.strictEqual(ip.toString(buf, offset, 4), '127.0.0.1')
+    })
 
-    it('should convert to buffer IPv6 address', function() {
-      var buf = ip.toBuffer('::1');
-      assert(/(00){15,15}01/.test(buf.toString('hex')));
-      assert.equal(ip.toString(buf), '::1');
-      assert.equal(ip.toString(ip.toBuffer('1::')), '1::');
-      assert.equal(ip.toString(ip.toBuffer('abcd::dcba')), 'abcd::dcba');
-    });
+    it('should convert to buffer IPv6 address', function () {
+      const buf = ip.toBuffer('::1')
+      assert(/(00){15,15}01/.test(buf.toString('hex')))
+      assert.strictEqual(ip.toString(buf), '::1')
+      assert.strictEqual(ip.toString(ip.toBuffer('1::')), '1::')
+      assert.strictEqual(ip.toString(ip.toBuffer('abcd::dcba')), 'abcd::dcba')
+    })
 
-    it('should convert to buffer IPv6 address in-place', function() {
-      var buf = new Buffer(128);
-      var offset = 64;
-      ip.toBuffer('::1', buf, offset);
-      assert(/(00){15,15}01/.test(buf.toString('hex', offset, offset + 16)));
-      assert.equal(ip.toString(buf, offset, 16), '::1');
-      assert.equal(ip.toString(ip.toBuffer('1::', buf, offset),
-                               offset, 16), '1::');
-      assert.equal(ip.toString(ip.toBuffer('abcd::dcba', buf, offset),
-                               offset, 16), 'abcd::dcba');
-    });
+    it('should convert to buffer IPv6 address in-place', function () {
+      const buf = new Buffer.alloc(128)
+      const offset = 64
+      ip.toBuffer('::1', buf, offset)
+      assert(/(00){15,15}01/.test(buf.toString('hex', offset, offset + 16)))
+      assert.strictEqual(ip.toString(buf, offset, 16), '::1')
+      assert.strictEqual(ip.toString(ip.toBuffer('1::', buf, offset),
+        offset, 16), '1::')
+      assert.strictEqual(ip.toString(ip.toBuffer('abcd::dcba', buf, offset),
+        offset, 16), 'abcd::dcba')
+    })
 
-    it('should convert to buffer IPv6 mapped IPv4 address', function() {
-      var buf = ip.toBuffer('::ffff:127.0.0.1');
-      assert.equal(buf.toString('hex'), '00000000000000000000ffff7f000001');
-      assert.equal(ip.toString(buf), '::ffff:7f00:1');
+    it('should convert to buffer IPv6 mapped IPv4 address', function () {
+      let buf = ip.toBuffer('::ffff:127.0.0.1')
+      assert.strictEqual(buf.toString('hex'), '00000000000000000000ffff7f000001')
+      assert.strictEqual(ip.toString(buf), '::ffff:7f00:1')
 
-      buf = ip.toBuffer('ffff::127.0.0.1');
-      assert.equal(buf.toString('hex'), 'ffff000000000000000000007f000001');
-      assert.equal(ip.toString(buf), 'ffff::7f00:1');
+      buf = ip.toBuffer('ffff::127.0.0.1')
+      assert.strictEqual(buf.toString('hex'), 'ffff000000000000000000007f000001')
+      assert.strictEqual(ip.toString(buf), 'ffff::7f00:1')
 
-      buf = ip.toBuffer('0:0:0:0:0:ffff:127.0.0.1');
-      assert.equal(buf.toString('hex'), '00000000000000000000ffff7f000001');
-      assert.equal(ip.toString(buf), '::ffff:7f00:1');
-    });
-  });
+      buf = ip.toBuffer('0:0:0:0:0:ffff:127.0.0.1')
+      assert.strictEqual(buf.toString('hex'), '00000000000000000000ffff7f000001')
+      assert.strictEqual(ip.toString(buf), '::ffff:7f00:1')
+    })
+  })
 
-  describe('fromPrefixLen() method', function() {
-    it('should create IPv4 mask', function() {
-      assert.equal(ip.fromPrefixLen(24), '255.255.255.0');
-    });
-    it('should create IPv6 mask', function() {
-      assert.equal(ip.fromPrefixLen(64), 'ffff:ffff:ffff:ffff::');
-    });
-    it('should create IPv6 mask explicitly', function() {
-      assert.equal(ip.fromPrefixLen(24, 'IPV6'), 'ffff:ff00::');
-    });
-  });
+  describe('fromPrefixLen() method', function () {
+    it('should create IPv4 mask', function () {
+      assert.strictEqual(ip.fromPrefixLen(24), '255.255.255.0')
+    })
+    it('should create IPv6 mask', function () {
+      assert.strictEqual(ip.fromPrefixLen(64), 'ffff:ffff:ffff:ffff::')
+    })
+    it('should create IPv6 mask explicitly', function () {
+      assert.strictEqual(ip.fromPrefixLen(24, 'IPV6'), 'ffff:ff00::')
+    })
+  })
 
-  describe('not() method', function() {
-    it('should reverse bits in address', function() {
-      assert.equal(ip.not('255.255.255.0'), '0.0.0.255');
-    });
-  });
+  describe('not() method', function () {
+    it('should reverse bits in address', function () {
+      assert.strictEqual(ip.not('255.255.255.0'), '0.0.0.255')
+    })
+  })
 
-  describe('or() method', function() {
-    it('should or bits in ipv4 addresses', function() {
-      assert.equal(ip.or('0.0.0.255', '192.168.1.10'), '192.168.1.255');
-    });
-    it('should or bits in ipv6 addresses', function() {
-      assert.equal(ip.or('::ff', '::abcd:dcba:abcd:dcba'),
-                   '::abcd:dcba:abcd:dcff');
-    });
-    it('should or bits in mixed addresses', function() {
-      assert.equal(ip.or('0.0.0.255', '::abcd:dcba:abcd:dcba'),
-                   '::abcd:dcba:abcd:dcff');
-    });
-  });
+  describe('or() method', function () {
+    it('should or bits in ipv4 addresses', function () {
+      assert.strictEqual(ip.or('0.0.0.255', '192.168.1.10'), '192.168.1.255')
+    })
+    it('should or bits in ipv6 addresses', function () {
+      assert.strictEqual(ip.or('::ff', '::abcd:dcba:abcd:dcba'),
+        '::abcd:dcba:abcd:dcff')
+    })
+    it('should or bits in mixed addresses', function () {
+      assert.strictEqual(ip.or('0.0.0.255', '::abcd:dcba:abcd:dcba'),
+        '::abcd:dcba:abcd:dcff')
+    })
+  })
 
-  describe('mask() method', function() {
-    it('should mask bits in address', function() {
-      assert.equal(ip.mask('192.168.1.134', '255.255.255.0'), '192.168.1.0');
-      assert.equal(ip.mask('192.168.1.134', '::ffff:ff00'), '::ffff:c0a8:100');
-    });
+  describe('mask() method', function () {
+    it('should mask bits in address', function () {
+      assert.strictEqual(ip.mask('192.168.1.134', '255.255.255.0'), '192.168.1.0')
+      assert.strictEqual(ip.mask('192.168.1.134', '::ffff:ff00'), '::ffff:c0a8:100')
+    })
 
-    it('should not leak data', function() {
-      for (var i = 0; i < 10; i++)
-        assert.equal(ip.mask('::1', '0.0.0.0'), '::');
-    });
-  });
+    it('should not leak data', function () {
+      for (let i = 0; i < 10; i++) { assert.strictEqual(ip.mask('::1', '0.0.0.0'), '::') }
+    })
+  })
 
-  describe('subnet() method', function() {
+  describe('subnet() method', function () {
     // Test cases calculated with http://www.subnet-calculator.com/
-    var ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.192');
+    const ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.192')
 
-    it('should compute ipv4 network address', function() {
-      assert.equal(ipv4Subnet.networkAddress, '192.168.1.128');
-    });
+    it('should compute ipv4 network address', function () {
+      assert.strictEqual(ipv4Subnet.networkAddress, '192.168.1.128')
+    })
 
-    it('should compute ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.129');
-    });
+    it('should compute ipv4 network\'s first address', function () {
+      assert.strictEqual(ipv4Subnet.firstAddress, '192.168.1.129')
+    })
 
-    it('should compute ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.190');
-    });
+    it('should compute ipv4 network\'s last address', function () {
+      assert.strictEqual(ipv4Subnet.lastAddress, '192.168.1.190')
+    })
 
-    it('should compute ipv4 broadcast address', function() {
-      assert.equal(ipv4Subnet.broadcastAddress, '192.168.1.191');
-    });
+    it('should compute ipv4 broadcast address', function () {
+      assert.strictEqual(ipv4Subnet.broadcastAddress, '192.168.1.191')
+    })
 
-    it('should compute ipv4 subnet number of addresses', function() {
-      assert.equal(ipv4Subnet.length, 64);
-    });
+    it('should compute ipv4 subnet number of addresses', function () {
+      assert.strictEqual(ipv4Subnet.length, 64)
+    })
 
-    it('should compute ipv4 subnet number of addressable hosts', function() {
-      assert.equal(ipv4Subnet.numHosts, 62);
-    });
+    it('should compute ipv4 subnet number of addressable hosts', function () {
+      assert.strictEqual(ipv4Subnet.numHosts, 62)
+    })
 
-    it('should compute ipv4 subnet mask', function() {
-      assert.equal(ipv4Subnet.subnetMask, '255.255.255.192');
-    });
+    it('should compute ipv4 subnet mask', function () {
+      assert.strictEqual(ipv4Subnet.subnetMask, '255.255.255.192')
+    })
 
-    it('should compute ipv4 subnet mask\'s length', function() {
-      assert.equal(ipv4Subnet.subnetMaskLength, 26);
-    });
+    it('should compute ipv4 subnet mask\'s length', function () {
+      assert.strictEqual(ipv4Subnet.subnetMaskLength, 26)
+    })
 
-    it('should know whether a subnet contains an address', function() {
-      assert.equal(ipv4Subnet.contains('192.168.1.180'), true);
-    });
+    it('should know whether a subnet contains an address', function () {
+      assert.strictEqual(ipv4Subnet.contains('192.168.1.180'), true)
+    })
 
-    it('should know whether a subnet does not contain an address', function() {
-      assert.equal(ipv4Subnet.contains('192.168.1.195'), false);
-    });
-  });
+    it('should know whether a subnet does not contain an address', function () {
+      assert.strictEqual(ipv4Subnet.contains('192.168.1.195'), false)
+    })
+  })
 
-  describe('subnet() method with mask length 32', function() {
+  describe('subnet() method with mask length 32', function () {
     // Test cases calculated with http://www.subnet-calculator.com/
-    var ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.255');
-    it('should compute ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.134');
-    });
+    const ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.255')
+    it('should compute ipv4 network\'s first address', function () {
+      assert.strictEqual(ipv4Subnet.firstAddress, '192.168.1.134')
+    })
 
-    it('should compute ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.134');
-    });
+    it('should compute ipv4 network\'s last address', function () {
+      assert.strictEqual(ipv4Subnet.lastAddress, '192.168.1.134')
+    })
 
-    it('should compute ipv4 subnet number of addressable hosts', function() {
-      assert.equal(ipv4Subnet.numHosts, 1);
-    });
-  });
+    it('should compute ipv4 subnet number of addressable hosts', function () {
+      assert.strictEqual(ipv4Subnet.numHosts, 1)
+    })
+  })
 
-  describe('subnet() method with mask length 31', function() {
+  describe('subnet() method with mask length 31', function () {
     // Test cases calculated with http://www.subnet-calculator.com/
-    var ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.254');
-    it('should compute ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.134');
-    });
+    const ipv4Subnet = ip.subnet('192.168.1.134', '255.255.255.254')
+    it('should compute ipv4 network\'s first address', function () {
+      assert.strictEqual(ipv4Subnet.firstAddress, '192.168.1.134')
+    })
 
-    it('should compute ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.135');
-    });
+    it('should compute ipv4 network\'s last address', function () {
+      assert.strictEqual(ipv4Subnet.lastAddress, '192.168.1.135')
+    })
 
-    it('should compute ipv4 subnet number of addressable hosts', function() {
-      assert.equal(ipv4Subnet.numHosts, 2);
-    });
-  });
+    it('should compute ipv4 subnet number of addressable hosts', function () {
+      assert.strictEqual(ipv4Subnet.numHosts, 2)
+    })
+  })
 
-  describe('cidrSubnet() method', function() {
+  describe('cidrSubnet() method', function () {
     // Test cases calculated with http://www.subnet-calculator.com/
-    var ipv4Subnet = ip.cidrSubnet('192.168.1.134/26');
+    const ipv4Subnet = ip.cidrSubnet('192.168.1.134/26')
 
-    it('should compute an ipv4 network address', function() {
-      assert.equal(ipv4Subnet.networkAddress, '192.168.1.128');
-    });
+    it('should compute an ipv4 network address', function () {
+      assert.strictEqual(ipv4Subnet.networkAddress, '192.168.1.128')
+    })
 
-    it('should compute an ipv4 network\'s first address', function() {
-      assert.equal(ipv4Subnet.firstAddress, '192.168.1.129');
-    });
+    it('should compute an ipv4 network\'s first address', function () {
+      assert.strictEqual(ipv4Subnet.firstAddress, '192.168.1.129')
+    })
 
-    it('should compute an ipv4 network\'s last address', function() {
-      assert.equal(ipv4Subnet.lastAddress, '192.168.1.190');
-    });
+    it('should compute an ipv4 network\'s last address', function () {
+      assert.strictEqual(ipv4Subnet.lastAddress, '192.168.1.190')
+    })
 
-    it('should compute an ipv4 broadcast address', function() {
-      assert.equal(ipv4Subnet.broadcastAddress, '192.168.1.191');
-    });
+    it('should compute an ipv4 broadcast address', function () {
+      assert.strictEqual(ipv4Subnet.broadcastAddress, '192.168.1.191')
+    })
 
-    it('should compute an ipv4 subnet number of addresses', function() {
-      assert.equal(ipv4Subnet.length, 64);
-    });
+    it('should compute an ipv4 subnet number of addresses', function () {
+      assert.strictEqual(ipv4Subnet.length, 64)
+    })
 
-    it('should compute an ipv4 subnet number of addressable hosts', function() {
-      assert.equal(ipv4Subnet.numHosts, 62);
-    });
+    it('should compute an ipv4 subnet number of addressable hosts', function () {
+      assert.strictEqual(ipv4Subnet.numHosts, 62)
+    })
 
-    it('should compute an ipv4 subnet mask', function() {
-      assert.equal(ipv4Subnet.subnetMask, '255.255.255.192');
-    });
+    it('should compute an ipv4 subnet mask', function () {
+      assert.strictEqual(ipv4Subnet.subnetMask, '255.255.255.192')
+    })
 
-    it('should compute an ipv4 subnet mask\'s length', function() {
-      assert.equal(ipv4Subnet.subnetMaskLength, 26);
-    });
+    it('should compute an ipv4 subnet mask\'s length', function () {
+      assert.strictEqual(ipv4Subnet.subnetMaskLength, 26)
+    })
 
-    it('should know whether a subnet contains an address', function() {
-      assert.equal(ipv4Subnet.contains('192.168.1.180'), true);
-    });
+    it('should know whether a subnet contains an address', function () {
+      assert.strictEqual(ipv4Subnet.contains('192.168.1.180'), true)
+    })
 
-    it('should know whether a subnet contains an address', function() {
-      assert.equal(ipv4Subnet.contains('192.168.1.195'), false);
-    });
+    it('should know whether a subnet contains an address', function () {
+      assert.strictEqual(ipv4Subnet.contains('192.168.1.195'), false)
+    })
+  })
 
-  });
+  describe('cidr() method', function () {
+    it('should mask address in CIDR notation', function () {
+      assert.strictEqual(ip.cidr('192.168.1.134/26'), '192.168.1.128')
+      assert.strictEqual(ip.cidr('2607:f0d0:1002:51::4/56'), '2607:f0d0:1002::')
+    })
+  })
 
-  describe('cidr() method', function() {
-    it('should mask address in CIDR notation', function() {
-      assert.equal(ip.cidr('192.168.1.134/26'), '192.168.1.128');
-      assert.equal(ip.cidr('2607:f0d0:1002:51::4/56'), '2607:f0d0:1002::');
-    });
-  });
+  describe('isstrictEqual() method', function () {
+    it('should check if addresses are strictEqual', function () {
+      assert(ip.isEqual('127.0.0.1', '::7f00:1'))
+      assert(!ip.isEqual('127.0.0.1', '::7f00:2'))
+      assert(ip.isEqual('127.0.0.1', '::ffff:7f00:1'))
+      assert(!ip.isEqual('127.0.0.1', '::ffaf:7f00:1'))
+      assert(ip.isEqual('::ffff:127.0.0.1', '::ffff:127.0.0.1'))
+      assert(ip.isEqual('::ffff:127.0.0.1', '127.0.0.1'))
+    })
+  })
 
-  describe('isEqual() method', function() {
-    it('should check if addresses are equal', function() {
-      assert(ip.isEqual('127.0.0.1', '::7f00:1'));
-      assert(!ip.isEqual('127.0.0.1', '::7f00:2'));
-      assert(ip.isEqual('127.0.0.1', '::ffff:7f00:1'));
-      assert(!ip.isEqual('127.0.0.1', '::ffaf:7f00:1'));
-      assert(ip.isEqual('::ffff:127.0.0.1', '::ffff:127.0.0.1'));
-      assert(ip.isEqual('::ffff:127.0.0.1', '127.0.0.1'));
-    });
-  });
+  describe('isPrivate() method', function () {
+    it('should check if an address is localhost', function () {
+      assert.strictEqual(ip.isPrivate('127.0.0.1'), true)
+    })
 
+    it('should check if an address is from a 192.168.x.x network', function () {
+      assert.strictEqual(ip.isPrivate('192.168.0.123'), true)
+      assert.strictEqual(ip.isPrivate('192.168.122.123'), true)
+      assert.strictEqual(ip.isPrivate('192.162.1.2'), false)
+    })
 
-  describe('isPrivate() method', function() {
-    it('should check if an address is localhost', function() {
-      assert.equal(ip.isPrivate('127.0.0.1'), true);
-    });
+    it('should check if an address is from a 172.16.x.x network', function () {
+      assert.strictEqual(ip.isPrivate('172.16.0.5'), true)
+      assert.strictEqual(ip.isPrivate('172.16.123.254'), true)
+      assert.strictEqual(ip.isPrivate('171.16.0.5'), false)
+      assert.strictEqual(ip.isPrivate('172.25.232.15'), true)
+      assert.strictEqual(ip.isPrivate('172.15.0.5'), false)
+      assert.strictEqual(ip.isPrivate('172.32.0.5'), false)
+    })
 
-    it('should check if an address is from a 192.168.x.x network', function() {
-      assert.equal(ip.isPrivate('192.168.0.123'), true);
-      assert.equal(ip.isPrivate('192.168.122.123'), true);
-      assert.equal(ip.isPrivate('192.162.1.2'), false);
-    });
+    it('should check if an address is from a 169.254.x.x network', function () {
+      assert.strictEqual(ip.isPrivate('169.254.2.3'), true)
+      assert.strictEqual(ip.isPrivate('169.254.221.9'), true)
+      assert.strictEqual(ip.isPrivate('168.254.2.3'), false)
+    })
 
-    it('should check if an address is from a 172.16.x.x network', function() {
-      assert.equal(ip.isPrivate('172.16.0.5'), true);
-      assert.equal(ip.isPrivate('172.16.123.254'), true);
-      assert.equal(ip.isPrivate('171.16.0.5'), false);
-      assert.equal(ip.isPrivate('172.25.232.15'), true);
-      assert.equal(ip.isPrivate('172.15.0.5'), false);
-      assert.equal(ip.isPrivate('172.32.0.5'), false);
-    });
+    it('should check if an address is from a 10.x.x.x network', function () {
+      assert.strictEqual(ip.isPrivate('10.0.2.3'), true)
+      assert.strictEqual(ip.isPrivate('10.1.23.45'), true)
+      assert.strictEqual(ip.isPrivate('12.1.2.3'), false)
+    })
 
-    it('should check if an address is from a 169.254.x.x network', function() {
-      assert.equal(ip.isPrivate('169.254.2.3'), true);
-      assert.equal(ip.isPrivate('169.254.221.9'), true);
-      assert.equal(ip.isPrivate('168.254.2.3'), false);
-    });
+    it('should check if an address is from a private IPv6 network', function () {
+      assert.strictEqual(ip.isPrivate('fd12:3456:789a:1::1'), true)
+      assert.strictEqual(ip.isPrivate('fe80::f2de:f1ff:fe3f:307e'), true)
+      assert.strictEqual(ip.isPrivate('::ffff:10.100.1.42'), true)
+      assert.strictEqual(ip.isPrivate('::FFFF:172.16.200.1'), true)
+      assert.strictEqual(ip.isPrivate('::ffff:192.168.0.1'), true)
+    })
 
-    it('should check if an address is from a 10.x.x.x network', function() {
-      assert.equal(ip.isPrivate('10.0.2.3'), true);
-      assert.equal(ip.isPrivate('10.1.23.45'), true);
-      assert.equal(ip.isPrivate('12.1.2.3'), false);
-    });
+    it('should check if an address is from the internet', function () {
+      assert.strictEqual(ip.isPrivate('165.225.132.33'), false) // joyent.com
+    })
 
-    it('should check if an address is from a private IPv6 network', function() {
-      assert.equal(ip.isPrivate('fd12:3456:789a:1::1'), true);
-      assert.equal(ip.isPrivate('fe80::f2de:f1ff:fe3f:307e'), true);
-      assert.equal(ip.isPrivate('::ffff:10.100.1.42'), true);
-      assert.equal(ip.isPrivate('::FFFF:172.16.200.1'), true);
-      assert.equal(ip.isPrivate('::ffff:192.168.0.1'), true);
-    });
+    it('should check if an address is a loopback IPv6 address', function () {
+      assert.strictEqual(ip.isPrivate('::'), true)
+      assert.strictEqual(ip.isPrivate('::1'), true)
+      assert.strictEqual(ip.isPrivate('fe80::1'), true)
+    })
+  })
 
-    it('should check if an address is from the internet', function() {
-      assert.equal(ip.isPrivate('165.225.132.33'), false); // joyent.com
-    });
+  describe('loopback() method', function () {
+    describe('undefined', function () {
+      it('should respond with 127.0.0.1', function () {
+        assert.strictEqual(ip.loopback(), '127.0.0.1')
+      })
+    })
 
-    it('should check if an address is a loopback IPv6 address', function() {
-      assert.equal(ip.isPrivate('::'), true);
-      assert.equal(ip.isPrivate('::1'), true);
-      assert.equal(ip.isPrivate('fe80::1'), true);
-    });
-  });
+    describe('ipv4', function () {
+      it('should respond with 127.0.0.1', function () {
+        assert.strictEqual(ip.loopback('ipv4'), '127.0.0.1')
+      })
+    })
 
-  describe('loopback() method', function() {
-    describe('undefined', function() {
-      it('should respond with 127.0.0.1', function() {
-        assert.equal(ip.loopback(), '127.0.0.1')
-      });
-    });
+    describe('ipv6', function () {
+      it('should respond with fe80::1', function () {
+        assert.strictEqual(ip.loopback('ipv6'), 'fe80::1')
+      })
+    })
+  })
 
-    describe('ipv4', function() {
-      it('should respond with 127.0.0.1', function() {
-        assert.equal(ip.loopback('ipv4'), '127.0.0.1')
-      });
-    });
-
-    describe('ipv6', function() {
-      it('should respond with fe80::1', function() {
-        assert.equal(ip.loopback('ipv6'), 'fe80::1')
-      });
-    });
-  });
-
-  describe('isLoopback() method', function() {
-    describe('127.0.0.1', function() {
-      it('should respond with true', function() {
+  describe('isLoopback() method', function () {
+    describe('127.0.0.1', function () {
+      it('should respond with true', function () {
         assert.ok(ip.isLoopback('127.0.0.1'))
-      });
-    });
+      })
+    })
 
     describe('127.8.8.8', function () {
       it('should respond with true', function () {
         assert.ok(ip.isLoopback('127.8.8.8'))
-      });
-    });
+      })
+    })
 
     describe('8.8.8.8', function () {
       it('should respond with false', function () {
-        assert.equal(ip.isLoopback('8.8.8.8'), false);
-      });
-    });
+        assert.strictEqual(ip.isLoopback('8.8.8.8'), false)
+      })
+    })
 
-    describe('fe80::1', function() {
-      it('should respond with true', function() {
+    describe('fe80::1', function () {
+      it('should respond with true', function () {
         assert.ok(ip.isLoopback('fe80::1'))
-      });
-    });
+      })
+    })
 
-    describe('::1', function() {
-      it('should respond with true', function() {
+    describe('::1', function () {
+      it('should respond with true', function () {
         assert.ok(ip.isLoopback('::1'))
-      });
-    });
+      })
+    })
 
-    describe('::', function() {
-      it('should respond with true', function() {
+    describe('::', function () {
+      it('should respond with true', function () {
         assert.ok(ip.isLoopback('::'))
-      });
-    });
-  });
-
-  describe('address() method', function() {
-    describe('undefined', function() {
-      it('should respond with a private ip', function() {
-        assert.ok(ip.isPrivate(ip.address()));
-      });
-    });
-
-    describe('private', function() {
-      [ undefined, 'ipv4', 'ipv6' ].forEach(function(family) {
-        describe(family, function() {
-          it('should respond with a private ip', function() {
-            assert.ok(ip.isPrivate(ip.address('private', family)));
-          });
-        });
-      });
-    });
-
-    var interfaces = os.networkInterfaces();
-
-    Object.keys(interfaces).forEach(function(nic) {
-      describe(nic, function() {
-        [ undefined, 'ipv4' ].forEach(function(family) {
-          describe(family, function() {
-            it('should respond with an ipv4 address', function() {
-              var addr = ip.address(nic, family);
-              assert.ok(!addr || net.isIPv4(addr));
-            });
-          });
-        });
-
-        describe('ipv6', function() {
-          it('should respond with an ipv6 address', function() {
-            var addr = ip.address(nic, 'ipv6');
-            assert.ok(!addr || net.isIPv6(addr));
-          });
-        })
-      });
-    });
-  });
-
-  describe('toLong() method', function() {
-    it('should respond with a int', function() {
-      assert.equal(ip.toLong('127.0.0.1'), 2130706433);
-      assert.equal(ip.toLong('255.255.255.255'), 4294967295);
-    });
-  });
-
-  describe('fromLong() method', function() {
-    it('should repond with ipv4 address', function() {
-      assert.equal(ip.fromLong(2130706433), '127.0.0.1');
-      assert.equal(ip.fromLong(4294967295), '255.255.255.255');
-    });
+      })
+    })
   })
-});
+
+  describe('address() method', function () {
+    describe('undefined', function () {
+      it('should respond with a private ip', function () {
+        assert.ok(ip.isPrivate(ip.address()))
+      })
+    })
+
+    describe('private', function () {
+      [ undefined, 'ipv4', 'ipv6' ].forEach(function (family) {
+        describe(family, function () {
+          it('should respond with a private ip', function () {
+            assert.ok(ip.isPrivate(ip.address('private', family)))
+          })
+        })
+      })
+    })
+
+    const interfaces = os.networkInterfaces()
+
+    Object.keys(interfaces).forEach(function (nic) {
+      describe(nic, function () {
+        [ undefined, 'ipv4' ].forEach(function (family) {
+          describe(family, function () {
+            it('should respond with an ipv4 address', function () {
+              const addr = ip.address(nic, family)
+              assert.ok(!addr || net.isIPv4(addr))
+            })
+          })
+        })
+
+        describe('ipv6', function () {
+          it('should respond with an ipv6 address', function () {
+            const addr = ip.address(nic, 'ipv6')
+            assert.ok(!addr || net.isIPv6(addr))
+          })
+        })
+      })
+    })
+  })
+
+  describe('toLong() method', function () {
+    it('should respond with a int', function () {
+      assert.strictEqual(ip.toLong('127.0.0.1'), 2130706433)
+      assert.strictEqual(ip.toLong('255.255.255.255'), 4294967295)
+    })
+  })
+
+  describe('fromLong() method', function () {
+    it('should repond with ipv4 address', function () {
+      assert.strictEqual(ip.fromLong(2130706433), '127.0.0.1')
+      assert.strictEqual(ip.fromLong(4294967295), '255.255.255.255')
+    })
+  })
+})


### PR DESCRIPTION
I have a long interface list of my devices, and npm `ip` package gives me the wrong IP always,
So I dig deep into files project and find out that we can retrieve interface IP address by the name of interfaces, but not mention in the document, so update document and inline document of `ip.address(name, family)` function in `lib.js`.

I start using `npm run test` and `npm fix` but unfortunately face to lots of error, so I replace `jscs` and `jshint` with `eslint` and config base on standard javascript styles.

meantime, when I use Eslint, appear Nodejs warning and deprecate function that's used in `ip` package, therefore I replaced them with the new one which aims to Nodejs 4 and above.