### PR TITLE
Add input validation for toLong

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -401,6 +401,9 @@ ip.address = function(name, family) {
 
 ip.toLong = function(ip) {
   var ipl = 0;
+  if (!this.isV4Format(ip)) {
+    return ipl;
+  }
   ip.split('.').forEach(function(octet) {
     ipl <<= 8;
     ipl += parseInt(octet);

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -396,6 +396,11 @@ describe('IP library for node.js', function() {
       assert.equal(ip.toLong('127.0.0.1'), 2130706433);
       assert.equal(ip.toLong('255.255.255.255'), 4294967295);
     });
+    it('should be able handle bad input', function() {
+      assert.equal(ip.toLong('fd12:3456:789a:1::1'), 0);
+      assert.equal(ip.toLong(null), 0);
+      assert.equal(ip.toLong(undefined), 0);
+    });
   });
 
   describe('fromLong() method', function() {


### PR DESCRIPTION
This pull request is adding input validation for `toLong` method as for example it is possible to only get long values from ipv4 addresses. Also, express for example can also give IP as null in some cases.


> NB: ci tests are failing, it is because mocha deps are not compatible with older nodes anymore (and the project has no lock file)... happy to resolve in separate in separet pull, but i see there is already few open pull that tackle that issue.