### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
+  - "8"
+  - "10"
+  - "node"
 
 before_install:
-  - travis_retry npm install -g npm@2.14.5
+  - travis_retry npm install -g npm@latest
   - travis_retry npm install
 
 script:


### PR DESCRIPTION
Test current LTS and actively supported Node.js branches.