### PR TITLE
allow prefixes in contains method

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -213,8 +213,8 @@ ip.subnet = function(addr, mask) {
     contains: function(other) {
       var cidrParts = other.split('/');
 
-      if (cidrParts[1]){
-        if (maskLength < cidrParts[1]) { // Container subnet must be bigger than contained subnet
+      if (cidrParts[1]) {
+        if (maskLength < cidrParts[1]) {
           other = ip.cidr(other);
         } else {
           return false;

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -211,6 +211,16 @@ ip.subnet = function(addr, mask) {
                 numberOfAddresses : numberOfAddresses - 2,
     length: numberOfAddresses,
     contains: function(other) {
+      var cidrParts = other.split('/');
+
+      if (cidrParts[1]){
+        if (maskLength < cidrParts[1]) { // Container subnet must be bigger than contained subnet
+          other = ip.cidr(other);
+        } else {
+          return false;
+        }
+      }
+
       return networkAddress === ip.toLong(ip.mask(other, mask));
     }
   };


### PR DESCRIPTION
This change allows to pass a prefix in the contains method, e.g. ip.cidrSubnet('192.168.0.0/16').contains('192.168.1.0/24')