### PR TITLE
Add the Shared Address Space

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -313,6 +313,11 @@ ip.isPrivate = function(addr) {
     /^::$/.test(addr);
 };
 
+ip.isShared = function(addr) {
+  return /^(::f{4}:)?100\.64\.([0-9]{1,3})\.([0-9]{1,3})$/i
+      .test(addr);
+};
+
 ip.isPublic = function(addr) {
   return !ip.isPrivate(addr);
 };

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -293,6 +293,16 @@ describe('IP library for node.js', function() {
     });
   });
 
+  describe('isShared() method', function() {
+    it('should check if an address is in the shared address space', function() {
+      assert.equal(ip.isShared('100.64.0.1'), true);
+    });
+
+    it('should not detect 100.* as the shared address space', function() {
+      assert.equal(ip.isShared('100.6.0.1'), false);
+    });
+  });
+
   describe('loopback() method', function() {
     describe('undefined', function() {
       it('should respond with 127.0.0.1', function() {


### PR DESCRIPTION

# Summary

https://tools.ietf.org/html/rfc6598

>   The Shared Address Space address range is 100.64.0.0/10.

# Why

We use `ip` and recently started using the shared ip range for some of our servers, which meant that some of our requests were being flagged as public. We added the isShared function so that we can also use that in our business logic.