### PR TITLE
fix: os.networkInterface result migrate

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -362,6 +362,17 @@ ip.loopback = function (family) {
 ip.address = function (name, family) {
   const interfaces = os.networkInterfaces();
 
+  // Node version 18.x after, os.networkInterfaces() returns { ... family: {4|6} }, not { ... family: {IPv4|IPv6} }
+  // [NodeJS Docs 18.x os.html#osnetworkinterfaces](https://nodejs.org/docs/latest-v18.x/api/os.html#osnetworkinterfaces)
+  // [NodeJS Docs 17.x os.html#osnetworkinterfaces](https://nodejs.org/docs/latest-v17.x/api/os.html#osnetworkinterfaces)
+  for (let name in interfaces) {
+    interfaces[name].forEach(function(details) {
+      if (typeof details.family === 'number') {
+        details.family = 'IPv' + details.family;
+      }
+    });
+  }
+
   //
   // Default to `ipv4`
   //


### PR DESCRIPTION
### Issue

Node version 18.x after, os.networkInterfaces() returns { ... family: {4|6} }, not { ... family: {IPv4|IPv6} }

### Reference
[NodeJS Docs 18.x os.html#osnetworkinterfaces](https://nodejs.org/docs/latest-v18.x/api/os.html#osnetworkinterfaces)
[NodeJS Docs 17.x os.html#osnetworkinterfaces](https://nodejs.org/docs/latest-v17.x/api/os.html#osnetworkinterfaces)