### PR TITLE
CVE 2023 42282

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -82,7 +82,7 @@ ip.toString = function (buff, offset, length) {
   return result;
 };
 
-const ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
+const ipv4Regex = /^((((\d{1,3})|(0x[0-9a-f]{1,2})|(0[0-7]{1,3}))\.){3,3})((\d{1,3})|(0x[0-9a-f]{1,2})|(0[0-7]{1,3}))$/i;
 const ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
 
 ip.isV4Format = function (ip) {
@@ -90,6 +90,7 @@ ip.isV4Format = function (ip) {
 };
 
 ip.isV6Format = function (ip) {
+  console.log(`testing for IPV6 regex ${ip} ${ipv6Regex.test(ip)}`);
   return ipv6Regex.test(ip);
 };
 
@@ -306,6 +307,17 @@ ip.isEqual = function (a, b) {
 };
 
 ip.isPrivate = function (addr) {
+
+  if (ip.isV4Format(addr)) {
+    // If not IPv6 then normalize IPv4 format to decimal octets
+    addr = ip.normalizeIpv4Address(addr);
+  }
+
+  if (ip.isLoopback(addr)) {
+    console.log('Detected Loopback in isPrivate function');
+    return true;
+  }
+
   return /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i
     .test(addr)
     || /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
@@ -324,6 +336,11 @@ ip.isPublic = function (addr) {
 };
 
 ip.isLoopback = function (addr) {
+  if (ip.isV4Format(addr)) {
+    // If not IPv6 then normalize IPv4 format to decimal octets
+    addr = ip.normalizeIpv4Address(addr);
+  }
+
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
     .test(addr)
     || /^fe80::1$/.test(addr)
@@ -405,18 +422,39 @@ ip.address = function (name, family) {
   return !all.length ? ip.loopback(family) : all[0];
 };
 
-ip.toLong = function (ip) {
+ip.toLong = function (ipInput) {
   let ipl = 0;
-  ip.split('.').forEach((octet) => {
+  ipInput.split('.').forEach((octet) => {
+    let tmpInt = 0;
+    if (ip.isOctetHexadecimal(octet)) {
+      tmpInt = parseInt(octet, 16);
+    } else if (ip.isOctetOctal(octet)) {
+      tmpInt = parseInt(octet, 8);
+    } else {
+      tmpInt = parseInt(octet, 10);
+    }
     ipl <<= 8;
-    ipl += parseInt(octet);
+    ipl += tmpInt;
   });
   return (ipl >>> 0);
 };
 
 ip.fromLong = function (ipl) {
+  // always returns ipv4 decimal octets
   return (`${ipl >>> 24}.${
     ipl >> 16 & 255}.${
     ipl >> 8 & 255}.${
     ipl & 255}`);
+};
+
+ip.isOctetHexadecimal = function (octet) {
+  return /0x[0-9a-f]+$/i.test(octet);
+};
+
+ip.isOctetOctal = function (octet) {
+  return /^0[0-7]*$/.test(octet);
+};
+
+ip.normalizeIpv4Address = function (addr) {
+  return ip.fromLong(ip.toLong(addr));
 };

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -343,8 +343,13 @@ ip.isLoopback = function (addr) {
 
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
     .test(addr)
-    || /^fe80::1$/.test(addr)
+    || /^0177\./.test(addr)
+    || /^0x7f\./i.test(addr)
+    || /^fe80::1$/i.test(addr)
     || /^::1$/.test(addr)
+    || /^0000:0000:0000:0000:0000:0000:0000:0001$/.test(addr)
+    || /^0:0:0:0:0:0:0:1$/.test(addr)
+    || /^:1$/.test(addr)
     || /^::$/.test(addr);
 };
 

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -90,7 +90,6 @@ ip.isV4Format = function (ip) {
 };
 
 ip.isV6Format = function (ip) {
-  console.log(`testing for IPV6 regex ${ip} ${ipv6Regex.test(ip)}`);
   return ipv6Regex.test(ip);
 };
 
@@ -314,7 +313,6 @@ ip.isPrivate = function (addr) {
   }
 
   if (ip.isLoopback(addr)) {
-    console.log('Detected Loopback in isPrivate function');
     return true;
   }
 
@@ -343,6 +341,7 @@ ip.isLoopback = function (addr) {
 
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
     .test(addr)
+    || /^127\./.test(addr)
     || /^0177\./.test(addr)
     || /^0x7f\./i.test(addr)
     || /^fe80::1$/i.test(addr)

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -301,6 +301,11 @@ describe('IP library for node.js', () => {
       assert.equal(ip.isPrivate('::ffff:10.100.1.42'), true);
       assert.equal(ip.isPrivate('::FFFF:172.16.200.1'), true);
       assert.equal(ip.isPrivate('::ffff:192.168.0.1'), true);
+      assert.equal(ip.isPrivate('::'), true);
+      assert.equal(ip.isPrivate('::1'), true);
+      assert.equal(ip.isPrivate('fe80::1'), true);
+      assert.equal(ip.isPrivate('0000:0000:0000:0000:0000:0000:0000:0001'), true);
+      assert.equal(ip.isPrivate('0:0:0:0:0:0:0:1'), true);
     });
 
     it('should check if an address is from the internet', () => {
@@ -308,9 +313,11 @@ describe('IP library for node.js', () => {
     });
 
     it('should check if an address is a loopback IPv6 address', () => {
-      assert.equal(ip.isPrivate('::'), true);
-      assert.equal(ip.isPrivate('::1'), true);
-      assert.equal(ip.isPrivate('fe80::1'), true);
+      assert.ok(ip.isLoopback('::'));
+      assert.ok(ip.isLoopback('::1'));
+      assert.ok(ip.isLoopback('fe80::1'));
+      assert.ok(ip.isLoopback('0000:0000:0000:0000:0000:0000:0000:0001'));
+      assert.ok(ip.isLoopback('0:0:0:0:0:0:0:1'));
     });
   });
 
@@ -338,6 +345,7 @@ describe('IP library for node.js', () => {
     describe('Should capture loopsbacks and loopback shorthand', () => {
       it('should respond with true', () => {
         assert.ok(ip.isLoopback('127.0.0.1'));
+        assert.ok(ip.isLoopback('127.1'));
         assert.ok(ip.isLoopback('0x7f.1'));
         assert.ok(ip.isLoopback('0177.1'));
         assert.ok(ip.isLoopback('fe80::1'));

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -344,6 +344,7 @@ describe('IP library for node.js', () => {
       it('should respond with true', () => {
         assert.ok(ip.isLoopback('127.0.0.1'));
         assert.ok(ip.isLoopback('0x7f.1'));
+        assert.ok(ip.isLoopback('0177.1'));
         assert.ok(ip.isLoopback('fe80::1'));
         assert.ok(ip.isLoopback('0000:0000:0000:0000:0000:0000:0000:0001'));
         assert.ok(ip.isLoopback('0:0:0:0:0:0:0:1'));

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -252,11 +252,6 @@ describe('IP library for node.js', () => {
   });
 
   describe('isPrivate() method', () => {
-    it('should check normalization if IPv4 addresses', () => {
-      let test = '0177.0.0.1';
-      let addr = ip.fromLong(ip.toLong(test));
-      console.log(`Converted Address eq: ${addr}`);
-    });
 
     it('should check if an address is localhost', () => {
       assert.equal(ip.isPrivate('127.0.0.1'), true);

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -340,9 +340,14 @@ describe('IP library for node.js', () => {
   });
 
   describe('isLoopback() method', () => {
-    describe('127.0.0.1', () => {
+    describe('Should capture loopsbacks and loopback shorthand', () => {
       it('should respond with true', () => {
         assert.ok(ip.isLoopback('127.0.0.1'));
+        assert.ok(ip.isLoopback('0x7f.1'));
+        assert.ok(ip.isLoopback('fe80::1'));
+        assert.ok(ip.isLoopback('0000:0000:0000:0000:0000:0000:0000:0001'));
+        assert.ok(ip.isLoopback('0:0:0:0:0:0:0:1'));
+        assert.ok(ip.isLoopback('::1'));
       });
     });
 


### PR DESCRIPTION
There seemed to be a lot of confusion in the other thread and uncertain about acceptance critieria.

This CVE seems to be focused on just detecting IPV4 private IPs with the vulnerability being to bypass them using hexadecimal octets.  This PR aims to be more developer friendly and readable as it seems a lot of people are reviewing this issue but not intimate with the subject matter or existing solution (myself included).

This PR tries to accomplish a few things:

- Improve the IPv4 format regex to detect the following groups (note this is for formatting not full validation):
  - Decimals are detected as 1 to 3 tokens of `[0-9] `
  - Hexadecimals are detected as '0x' followed by 1 to 2 tokens of `[0-9a-f]` case insensitive
  - Octals are detected as a leading 0 followed by 1 to 3 tokens of `[0-7]
  - These oblige the same functionality for parsing ipv4 as curl and ping
- For the purposes determining private IPs and loopback IPs (an exit condition for private IPs), these functions always convert hex, octal, or decimal (mixed if present) octets to into a standard decimal-octet ipv4 address string.
- Appropriate test cases should be available, but there are probably some that are missing.  A good review could probably help with this.
- Enhancements for loopback detection (mostly handled by normalization, but shorthands are now included)

This PR does not address ipv6 logic outside of additional loopback address detection tests.

EDIT:  The reason that ip.isLoopback has it's own call to ip.normalizeIpv4Address is due to it being called in other functions.  Normalization will prevent X.X.X.X with tricky hex or octal from bypassing loopback detection regex tests.  Example `0x7f.0x0.0x0.0x1`

I might have some concerns about calling this twice in many cases were a standard X.X.X.X formatted IP will need to be normalized for the isPriviate and the nested call to isLoopback.  We could probably re-arrange some other logic to normalize the calling tree that we see, but I suspect outside of this paring, this library is meant as a utility and as such, there may not be a consistent input to any given function.