### PR TITLE
lib: fix parsing for ill-formed addresses

### DIFF
--- a/test/api-test.js
+++ b/test/api-test.js
@@ -352,8 +352,17 @@ describe('IP library for node.js', () => {
       assert.equal(ip.isPrivate('fe80::1'), true);
     });
 
-    it('should correctly identify hexadecimal IP addresses like \'0x7f.1\' as private', () => {
-      assert.equal(ip.isPrivate('0x7f.1'), true);
+    [
+      '0x7f.1',
+      '0300.0XA8.3', // 192.168.0.3
+      '01200034567', // 10.0.57.119
+      '012.1.2.3',   // 10.1.2.3
+    ].forEach((address) => {
+      describe(address, () => {
+        it('should respond with true', () => {
+          assert.equal(ip.isPrivate(address), true);
+        });
+      });
     });
   });
 
@@ -378,39 +387,51 @@ describe('IP library for node.js', () => {
   });
 
   describe('isLoopback() method', () => {
-    describe('127.0.0.1', () => {
-      it('should respond with true', () => {
-        assert.ok(ip.isLoopback('127.0.0.1'));
+    [
+      '127.0.0.1',
+      '127.8.8.8',
+      'fe80::1',
+      'fe80::0001',
+      '::fFFf:127.0.0.1',
+      '::',
+      '::0',
+      '::000',
+      '::1',
+      '::01',
+      '::001',
+      '0::1',
+      '000:0:0000::01',
+      '000:0:0000:0:000:0:00:001',
+      '0177.0.0.1',
+      '0177.0.1',
+      '0177.1',
+      '017700000001',
+      '0x7f.0.0.1',
+      '0x7F.0.1',
+      '0X7f.1',
+      '0X7F000001',
+      '127.0.1',
+      '127.1',
+      '2130706433',
+      '127.00.0x1',
+      '127.0.0x0.1',
+      '0x7f.01',
+    ].forEach((address) => {
+      describe(address, () => {
+        it('should respond with true', () => {
+          assert.equal(ip.isLoopback(address), true);
+        });
       });
     });
 
-    describe('127.8.8.8', () => {
-      it('should respond with true', () => {
-        assert.ok(ip.isLoopback('127.8.8.8'));
-      });
-    });
-
-    describe('8.8.8.8', () => {
-      it('should respond with false', () => {
-        assert.equal(ip.isLoopback('8.8.8.8'), false);
-      });
-    });
-
-    describe('fe80::1', () => {
-      it('should respond with true', () => {
-        assert.ok(ip.isLoopback('fe80::1'));
-      });
-    });
-
-    describe('::1', () => {
-      it('should respond with true', () => {
-        assert.ok(ip.isLoopback('::1'));
-      });
-    });
-
-    describe('::', () => {
-      it('should respond with true', () => {
-        assert.ok(ip.isLoopback('::'));
+    [
+      '8.8.8.8',
+      '192.168.1.1',
+    ].forEach((address) => {
+      describe(address, () => {
+        it('should respond with false', () => {
+          assert.equal(ip.isLoopback(address), false);
+        });
       });
     });
   });
@@ -467,43 +488,5 @@ describe('IP library for node.js', () => {
       assert.equal(ip.fromLong(2130706433), '127.0.0.1');
       assert.equal(ip.fromLong(4294967295), '255.255.255.255');
     });
-  });
-
-  // IPv4 loopback in octal notation
-  it('should return true for octal representation "0177.0.0.1"', () => {
-    assert.equal(ip.isLoopback('0177.0.0.1'), true);
-  });
-
-  it('should return true for octal representation "0177.0.1"', () => {
-    assert.equal(ip.isLoopback('0177.0.1'), true);
-  });
-
-  it('should return true for octal representation "0177.1"', () => {
-    assert.equal(ip.isLoopback('0177.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.0.0.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.0.0.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.0.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.0.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.1'), true);
-  });
-
-  // IPv4 loopback as a single long integer
-  it('should return true for single long integer representation "2130706433"', () => {
-    assert.equal(ip.isLoopback('2130706433'), true);
-  });
-
-  // IPv4 non-loopback address
-  it('should return false for "192.168.1.1"', () => {
-    assert.equal(ip.isLoopback('192.168.1.1'), false);
   });
 });


### PR DESCRIPTION
#138 does not completely fix CVE-2023-42282.

Some examples quoted from the failing tests added here:

- `127.1`, `127.0.1`, `127.00.0x1`, `127.0.0x0.1`
- `01200034567`: `Number('01200034567') === 1200034567` while `01200034567 === 167786871` in JavaScript, suprise!
- `012.1.2.3`: `ip.isV6Format('012.1.2.3') === true`, so it's not normalized :)
- `fe80::0001`, we can have leading zeros, and, more: `000:0:0000::01`, `000:0:0000:0:000:0:00:001`
- `::fFFf:127.0.0.1`: there are `/i` in many places, but not here

---

Now I think we need a new CVE. A quick way to get one is to open a security advisory in this repository. @indutny Could you please [enable private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)? Or does anyone know whether it is possible to properly revoke the "patched version" in the previous CVE? (Based on the activity level of this repository, the existence of the previous CVE, and the number of uncovered cases, I chose public disclosure here.)

~~UPD: I'm not sure whether editing the advisory or requesting a new CVE is more appreciated, also wondering how Dependabot would react to this modification, but I opened https://github.com/github/advisory-database/pull/3617.~~

---

See #144 for my new attempt to fix it.

---

IP address handling is hard. ~~I'm not sure how to properly implement it based on the current codes. (Note that my tests are still not exhaustive.) Maybe we should actually *parse* the addresses instead of relying on regular expressions.~~ I didn't notice the `toBuffer` function. Maybe we should fix it and use it for other functions.

Also, the semantics of the functions on invalid addresses seem unclear and inconsistent. I suggest a new major release (v3) to change some return values on invalid addresses. Maybe also fix #61 there.