### PR TITLE
lib: use Node.js net lib and reject malformed addresses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 12, 14, 16, 18 ]
+        node: [ 14, 16, 18, 20 ]
     name: Node ${{ matrix.node }} sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255
 ip.isPrivate('127.0.0.1') // true
 ip.isV4Format('127.0.0.1'); // true
 ip.isV6Format('::ffff:127.0.0.1'); // true
+ip.isValid('127.0.0.1'); // true
 
 // operate on buffers in-place
 var buf = new Buffer(128);
@@ -65,6 +66,7 @@ ip.fromLong(2130706433); // '127.0.0.1'
 // malformed addresses and normalization
 ip.normalizeStrict('0::01'); // '::1'
 ip.isPrivate('0x7f.1'); // throw error
+ip.isValidAndPrivate('0x7f.1'); // false
 ip.normalizeStrict('0x7f.1'); // throw error
 var normalized = ip.normalizeLax('0x7f.1'); // 127.0.0.1
 ip.isPrivate(normalized); // true

--- a/README.md
+++ b/README.md
@@ -58,10 +58,16 @@ ip.cidrSubnet('192.168.1.134/26')
 // range checking
 ip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true
 
-
 // ipv4 long conversion
 ip.toLong('127.0.0.1'); // 2130706433
 ip.fromLong(2130706433); // '127.0.0.1'
+
+// malformed addresses and normalization
+ip.normalizeStrict('0::01'); // '::1'
+ip.isPrivate('0x7f.1'); // throw error
+ip.normalizeStrict('0x7f.1'); // throw error
+var normalized = ip.normalizeLax('0x7f.1'); // 127.0.0.1
+ip.isPrivate(normalized); // true
 ```
 
 ### License

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -455,6 +455,7 @@ ip.normalizeToLong = function (addr) {
 
   switch (n) {
   case 1:
+    if (parts[0] > 0xffffffff) return -1;
     val = parts[0];
     break;
   case 2:

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -87,7 +87,7 @@ ip.isV4Format = net.isIPv4;
 
 ip.isV6Format = net.isIPv6;
 
-ip.normalize = function (addr) {
+ip.normalizeStrict = function (addr) {
   const family = net.isIPv4(addr) ? 'ipv4' : net.isIPv6(addr) ? 'ipv6' : null;
   if (family === null) {
     throw new Error(`Invalid ip address: ${addr}`);
@@ -309,7 +309,7 @@ ip.isEqual = function (a, b) {
 };
 
 ip.isPrivate = function (addr) {
-  addr = ip.normalize(addr);
+  addr = ip.normalizeStrict(addr);
 
   // check private ranges
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
@@ -328,7 +328,7 @@ ip.isPublic = function (addr) {
 };
 
 ip.isLoopback = function (addr) {
-  addr = ip.normalize(addr);
+  addr = ip.normalizeStrict(addr);
 
   return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr)
     || /^fe80::1$/i.test(addr)
@@ -427,6 +427,8 @@ ip.fromLong = function (ipl) {
 };
 
 ip.normalizeToLong = function (addr) {
+  if (typeof addr !== 'string') return -1;
+
   const parts = addr.split('.').map(part => {
     // Handle hexadecimal format
     if (part.startsWith('0x') || part.startsWith('0X')) {
@@ -472,4 +474,16 @@ ip.normalizeToLong = function (addr) {
   }
 
   return val >>> 0;
+};
+
+ip.normalizeLax = function(addr) {
+  if (ip.isV6Format(addr)) {
+    const { address } = new net.SocketAddress({ address: addr, family: 'ipv6' });
+    return address;
+  }
+  const ipl = ip.normalizeToLong(addr);
+  if (ipl < 0) {
+    throw Error(`Invalid ip address: ${addr}`);
+  }
+  return ip.fromLong(ipl);
 };

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1,6 +1,7 @@
 const ip = exports;
 const { Buffer } = require('buffer');
 const os = require('os');
+const net = require('net');
 
 ip.toBuffer = function (ip, buff, offset) {
   offset = ~~offset;
@@ -82,15 +83,17 @@ ip.toString = function (buff, offset, length) {
   return result;
 };
 
-const ipv4Regex = /^(\d{1,3}\.){3,3}\d{1,3}$/;
-const ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i;
+ip.isV4Format = net.isIPv4;
 
-ip.isV4Format = function (ip) {
-  return ipv4Regex.test(ip);
-};
+ip.isV6Format = net.isIPv6;
 
-ip.isV6Format = function (ip) {
-  return ipv6Regex.test(ip);
+ip.normalize = function (addr) {
+  const family = net.isIPv4(addr) ? 'ipv4' : net.isIPv6(addr) ? 'ipv6' : null;
+  if (family === null) {
+    throw new Error(`Invalid ip address: ${addr}`);
+  }
+  const { address } = new net.SocketAddress({ address: addr, family });
+  return address;
 };
 
 function _normalizeFamily(family) {
@@ -306,26 +309,13 @@ ip.isEqual = function (a, b) {
 };
 
 ip.isPrivate = function (addr) {
-  // check loopback addresses first
-  if (ip.isLoopback(addr)) {
-    return true;
-  }
-
-  // ensure the ipv4 address is valid
-  if (!ip.isV6Format(addr)) {
-    const ipl = ip.normalizeToLong(addr);
-    if (ipl < 0) {
-      throw new Error('invalid ipv4 address');
-    }
-    // normalize the address for the private range checks that follow
-    addr = ip.fromLong(ipl);
-  }
+  addr = ip.normalize(addr);
 
   // check private ranges
-  return /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
+  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
+    || /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
     || /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
-    || /^(::f{4}:)?172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})$/i
-      .test(addr)
+    || /^(::f{4}:)?172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
     || /^(::f{4}:)?169\.254\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr)
     || /^f[cd][0-9a-f]{2}:/i.test(addr)
     || /^fe80:/i.test(addr)
@@ -338,15 +328,9 @@ ip.isPublic = function (addr) {
 };
 
 ip.isLoopback = function (addr) {
-  // If addr is an IPv4 address in long integer form (no dots and no colons), convert it
-  if (!/\./.test(addr) && !/:/.test(addr)) {
-    addr = ip.fromLong(Number(addr));
-  }
+  addr = ip.normalize(addr);
 
-  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
-    .test(addr)
-    || /^0177\./.test(addr)
-    || /^0x7f\./i.test(addr)
+  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr)
     || /^fe80::1$/i.test(addr)
     || /^::1$/.test(addr)
     || /^::$/.test(addr);

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -87,9 +87,20 @@ ip.isV4Format = net.isIPv4;
 
 ip.isV6Format = net.isIPv6;
 
+ip.isValid = function (addr) {
+  return net.isIP(addr) !== 0;
+};
+
 ip.normalizeStrict = function (addr) {
-  const family = net.isIPv4(addr) ? 'ipv4' : net.isIPv6(addr) ? 'ipv6' : null;
-  if (family === null) {
+  let family;
+  switch (net.isIP(addr)) {
+  case 4:
+    family = 'ipv4';
+    break;
+  case 6:
+    family = 'ipv6';
+    break;
+  default:
     throw new Error(`Invalid ip address: ${addr}`);
   }
   const { address } = new net.SocketAddress({ address: addr, family });
@@ -325,6 +336,22 @@ ip.isPrivate = function (addr) {
 
 ip.isPublic = function (addr) {
   return !ip.isPrivate(addr);
+};
+
+ip.isValidAndPrivate = function (addr) {
+  try {
+    return ip.isPrivate(addr);
+  } catch {
+    return false;
+  }
+};
+
+ip.isValidAndPublic = function (addr) {
+  try {
+    return ip.isPublic(addr);
+  } catch {
+    return false;
+  }
 };
 
 ip.isLoopback = function (addr) {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -251,7 +251,7 @@ describe('IP library for node.js', () => {
     });
   });
 
-  describe('normalizeIpv4() method', () => {
+  describe('normalizeToLong() method', () => {
     // Testing valid inputs with different notations
     it('should correctly normalize "127.0.0.1"', () => {
       assert.equal(ip.normalizeToLong('127.0.0.1'), 2130706433);
@@ -466,6 +466,66 @@ describe('IP library for node.js', () => {
     it('should repond with ipv4 address', () => {
       assert.equal(ip.fromLong(2130706433), '127.0.0.1');
       assert.equal(ip.fromLong(4294967295), '255.255.255.255');
+    });
+  });
+
+  describe('normalizeStrict() method', () => {
+    it('should keep valid IPv4 addresses', () => {
+      assert.equal(ip.normalizeStrict('1.1.1.1'), '1.1.1.1');
+    });
+
+    it('should normalize IPv6 leading zeros', () => {
+      assert.equal(ip.normalizeStrict('00:0::000:01'), '::1');
+    });
+
+    it('should normalize IPv6 letter casing', () => {
+      assert.equal(ip.normalizeStrict('aBCd::eF12'), 'abcd::ef12');
+    });
+
+    it('should normalize IPv6 addresses with embedded IPv4 addresses', () => {
+      assert.equal(ip.normalizeStrict('::ffff:7f00:1'), '::ffff:127.0.0.1');
+      assert.equal(ip.normalizeStrict('::1234:5678'), '::18.52.86.120');
+    });
+
+    it('should reject malformed addresses', () => {
+      assert.throws(() => ip.normalizeStrict('127.0.1'));
+      assert.throws(() => ip.normalizeStrict('0x7f.1'));
+      assert.throws(() => ip.normalizeStrict('012.1'));
+    });
+  });
+
+  describe('normalizeLax() method', () => {
+    it('should normalize hex and oct addresses', () => {
+      assert.equal(ip.normalizeLax('0x7f.0x0.0x0.0x1'), '127.0.0.1');
+      assert.equal(ip.normalizeLax('012.34.0X56.0xAb'), '10.34.86.171');
+    });
+
+    it('should normalize 3-part addresses', () => {
+      assert.equal(ip.normalizeLax('192.168.1'), '192.168.0.1');
+    });
+
+    it('should normalize 2-part addresses', () => {
+      assert.equal(ip.normalizeLax('012.3'), '10.0.0.3');
+      assert.equal(ip.normalizeLax('012.0xabcdef'), '10.171.205.239');
+    });
+
+    it('should normalize single integer addresses', () => {
+      assert.equal(ip.normalizeLax('0x7f000001'), '127.0.0.1');
+      assert.equal(ip.normalizeLax('123456789'), '7.91.205.21');
+      assert.equal(ip.normalizeLax('01200034567'), '10.0.57.119');
+    });
+
+    it('should throw on invalid addresses', () => {
+      assert.throws(() => ip.normalizeLax('127.0.0xabcde'));
+      assert.throws(() => ip.normalizeLax('12345678910'));
+      assert.throws(() => ip.normalizeLax('0o1200034567'));
+      assert.throws(() => ip.normalizeLax('127.0.0.0.1'));
+      assert.throws(() => ip.normalizeLax('127.0.0.-1'));
+      assert.throws(() => ip.normalizeLax('-1'));
+    });
+
+    it('should normalize IPv6 leading zeros', () => {
+      assert.equal(ip.normalizeStrict('00:0::000:01'), '::1');
     });
   });
 });

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -528,4 +528,51 @@ describe('IP library for node.js', () => {
       assert.equal(ip.normalizeStrict('00:0::000:01'), '::1');
     });
   });
+
+  describe('isValid(), isV4Format()), isV6Format() methods', () => {
+    it('should validate ipv4 addresses', () => {
+      assert.equal(ip.isValid('1.1.1.1'), true);
+      assert.equal(ip.isValid('1.1.1.1.1'), false);
+      assert.equal(ip.isValid('1.1.1.256'), false);
+      assert.equal(ip.isValid('127.1'), false);
+      assert.equal(ip.isValid('127.0.0.01'), false);
+      assert.equal(ip.isValid('0x7f.0.0.1'), false);
+      assert.equal(ip.isV4Format('1.2.3.4'), true);
+      assert.equal(ip.isV6Format('1.2.3.4'), false);
+    });
+
+    it('should validate ipv6 addresses', () => {
+      assert.equal(ip.isValid('::1'), true);
+      assert.equal(ip.isValid('::1:1.2.3.4'), true);
+      assert.equal(ip.isValid('1::2::3'), false);
+      assert.equal(ip.isV4Format('::ffff:127.0.0.1'), false);
+      assert.equal(ip.isV6Format('::ffff:127.0.0.1'), true);
+    });
+  });
+
+  describe('isValidAndPublic() method', () => {
+    it('should return true on valid public addresses', () => {
+      assert.equal(ip.isValidAndPublic('8.8.8.8'), true);
+    });
+    it('should return false on invalid addresses', () => {
+      assert.equal(ip.isValidAndPublic('8.8.8'), false);
+      assert.equal(ip.isValidAndPublic('8.8.8.010'), false);
+    });
+    it('should return false on valid private addresses', () => {
+      assert.equal(ip.isValidAndPublic('127.0.0.1'), false);
+    });
+  });
+
+  describe('isValidAndPrivate() method', () => {
+    it('should return true on valid private addresses', () => {
+      assert.equal(ip.isValidAndPrivate('192.168.1.2'), true);
+    });
+    it('should return false on invalid addresses', () => {
+      assert.equal(ip.isValidAndPrivate('127.1'), false);
+      assert.equal(ip.isValidAndPrivate('0x7f.0.0.1'), false);
+    });
+    it('should return false on valid public addresses', () => {
+      assert.equal(ip.isValidAndPrivate('8.8.8.8'), false);
+    });
+  });
 });

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -352,8 +352,8 @@ describe('IP library for node.js', () => {
       assert.equal(ip.isPrivate('fe80::1'), true);
     });
 
-    it('should correctly identify hexadecimal IP addresses like \'0x7f.1\' as private', () => {
-      assert.equal(ip.isPrivate('0x7f.1'), true);
+    it('should reject hexadecimal IP addresses like "0x7f.1"', () => {
+      assert.throws(() => ip.isPrivate('0x7f.1'));
     });
   });
 
@@ -467,43 +467,5 @@ describe('IP library for node.js', () => {
       assert.equal(ip.fromLong(2130706433), '127.0.0.1');
       assert.equal(ip.fromLong(4294967295), '255.255.255.255');
     });
-  });
-
-  // IPv4 loopback in octal notation
-  it('should return true for octal representation "0177.0.0.1"', () => {
-    assert.equal(ip.isLoopback('0177.0.0.1'), true);
-  });
-
-  it('should return true for octal representation "0177.0.1"', () => {
-    assert.equal(ip.isLoopback('0177.0.1'), true);
-  });
-
-  it('should return true for octal representation "0177.1"', () => {
-    assert.equal(ip.isLoopback('0177.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.0.0.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.0.0.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.0.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.0.1'), true);
-  });
-
-  // IPv4 loopback in hexadecimal notation
-  it('should return true for hexadecimal representation "0x7f.1"', () => {
-    assert.equal(ip.isLoopback('0x7f.1'), true);
-  });
-
-  // IPv4 loopback as a single long integer
-  it('should return true for single long integer representation "2130706433"', () => {
-    assert.equal(ip.isLoopback('2130706433'), true);
-  });
-
-  // IPv4 non-loopback address
-  it('should return false for "192.168.1.1"', () => {
-    assert.equal(ip.isLoopback('192.168.1.1'), false);
   });
 });


### PR DESCRIPTION
See #143. Given the current API of this library, I believe that it's not suitable to support malformed addresses like `0x7f.1`. It's hard to parse them correctly in all cases. It's better to throw errors for them.

This PR uses the Node.js `net` library so it should be reliable.

I suggest releasing v3 after merging this, because:

1. `net.SocketAddress` is added in Node v15.14.0 and v14.18.0. I think it's reasonable to drop support for older Node versions because Node 12 has reached end-of-life since 2022-04-30. If the user cares about security, they should use a new Node version.
2. I would consider throwing new errors as a breaking change.
3. Dropping support for malformed addresses could also be a breaking change.

We could try to (partially) fix the security concerns in a compatible way in v2 (and v1) in another pull request.