### PR TITLE
Loopback uppercase address not detected

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -343,7 +343,7 @@ ip.isLoopback = function (addr) {
     addr = ip.fromLong(Number(addr));
   }
 
-  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/
+  return /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/i
     .test(addr)
     || /^0177\./.test(addr)
     || /^0x7f\./i.test(addr)

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -413,6 +413,12 @@ describe('IP library for node.js', () => {
         assert.ok(ip.isLoopback('::'));
       });
     });
+
+    describe('::FFFF:127.0.0.1', () => {
+      it('should respond with true', () => {
+        assert.ok(ip.isLoopback('::FFFF:127.0.0.1'));
+      });
+    });
   });
 
   describe('address() method', () => {


### PR DESCRIPTION
This regex was case-sensitive and only matched lowercase `ffff`.
In other places matching is already case-insensitive.
https://github.com/indutny/node-ip/blob/3b0994a74eca51df01f08c40d6a65ba0e1845d04/lib/ip.js#L325-L329